### PR TITLE
Add lhs for tree building annotations

### DIFF
--- a/src/grammars/CongoCC.ccc
+++ b/src/grammars/CongoCC.ccc
@@ -1096,7 +1096,14 @@ TreeNodeDescriptor #TreeBuildingAnnotation :
 ;
 
 InlineTreeNodeDescriptor #TreeBuildingAnnotation :
-  [<BACKSLASH>] <HASH> Name
+  [ 
+      <BACKSLASH>
+    |
+      Name {CURRENT_NODE.setLHS((Name)peekNode());} "=" 
+      =>||
+  ]
+  <HASH> =>|| 
+  Name  
   (
     SCAN ~("(") => {}
     |
@@ -1124,6 +1131,7 @@ INJECT TreeBuildingAnnotation :
 {
     @Property String initialShorthand;
     @Property Expression condition;
+    @Property Name LHS;
     /**
      * Just returns whatever comes after the hash ("#") including "void", etc.
      */
@@ -1760,8 +1768,8 @@ ExpansionUnit #void :
  )
  {Expansion result = (Expansion) peekNode();}
  [
-    SCAN 1 ~\...\Lookahead => 
-    InlineTreeNodeDescriptor
+    SCAN ~\...\Lookahead => 
+    InlineTreeNodeDescriptor =>||
     { result.setTreeNodeBehavior((TreeBuildingAnnotation) peekNode()); }
  ]
 ;


### PR DESCRIPTION
Jon, for your consideration two little changes that comprise ones I have made on my path to JTB visitor-compatible trees.  These two are, I believe, backwards compatible and are general purpose extensions to CongoCC.  I've tested them with my compiler, of course, and I have run the standard test target in the build.  I haven't considered their impact beyond Java, but I wanted to let you see them in hopes that they could be merged sooner or later (and I could stop merging them in my parallel experimental congo).