### PR TITLE
Declare fields on a separate line, use space between method parameters

### DIFF
--- a/src/templates/java/Lexer.java.ftl
+++ b/src/templates/java/Lexer.java.ftl
@@ -180,10 +180,11 @@ public class ${settings.lexerClassName} extends TokenSource
        if (position >= input.length()) {
           return new MatchInfo(EOF, 0);
        }
-       int start = position, matchLength = 0;
+       int start = position;
+       int matchLength = 0;
        TokenType matchedType = TokenType.INVALID;
-       BitSet currentStates = new BitSet(${lexerData.maxNfaStates}),
-              nextStates=new BitSet(${lexerData.maxNfaStates});
+       BitSet currentStates = new BitSet(${lexerData.maxNfaStates});
+       BitSet nextStates=new BitSet(${lexerData.maxNfaStates});
         // the core NFA loop
         do {
             // Holder for the new type (if any) matched on this iteration

--- a/src/templates/java/LookaheadRoutines.java.ftl
+++ b/src/templates/java/LookaheadRoutines.java.ftl
@@ -434,7 +434,8 @@
 [#macro ScanCodeChoice choice]
    [@CU.newVar settings.baseTokenClassName, "currentLookaheadToken"/]
    int remainingLookahead${CU.newVarIndex} = remainingLookahead;
-   boolean hitFailure${CU.newVarIndex} = hitFailure, passedPredicate${CU.newVarIndex} = passedPredicate;
+   boolean hitFailure${CU.newVarIndex} = hitFailure;
+   boolean passedPredicate${CU.newVarIndex} = passedPredicate;
    try {
   [#list choice.choices as subseq]
      passedPredicate = false;

--- a/src/templates/java/Parser.java.ftl
+++ b/src/templates/java/Parser.java.ftl
@@ -55,9 +55,12 @@ ${settings.baseTokenClassName} lastConsumedToken;
 private TokenType nextTokenType;
 private ${settings.baseTokenClassName} currentLookaheadToken;
 private int remainingLookahead;
-private boolean hitFailure, passedPredicate;
-private String currentlyParsedProduction, currentLookaheadProduction;
-private int lookaheadRoutineNesting, passedPredicateThreshold = -1;
+private boolean hitFailure;
+private boolean passedPredicate;
+private String currentlyParsedProduction;
+private String currentLookaheadProduction;
+private int lookaheadRoutineNesting;
+private int passedPredicateThreshold = -1;
 EnumSet<TokenType> outerFollowSet;
 
 [#if settings.legacyGlitchyLookahead]

--- a/src/templates/java/Token.java.ftl
+++ b/src/templates/java/Token.java.ftl
@@ -55,7 +55,8 @@ public class ${settings.baseTokenClassName} ${implementsNode} {
     
     private TokenType type=TokenType.DUMMY;
     
-    private int beginOffset, endOffset;
+    private int beginOffset;
+    private int endOffset;
     
     private boolean unparsed;
 
@@ -72,7 +73,8 @@ public class ${settings.baseTokenClassName} ${implementsNode} {
 
 [#if settings.tokenChaining]
 
-    private ${settings.baseTokenClassName} prependedToken, appendedToken;
+    private ${settings.baseTokenClassName} prependedToken;
+    private ${settings.baseTokenClassName} appendedToken;
 
     private boolean inserted;
 
@@ -183,7 +185,9 @@ public class ${settings.baseTokenClassName} ${implementsNode} {
 
 
 [#if settings.faultTolerant]
-    private boolean virtual, skipped, dirty;
+    private boolean virtual;
+    private boolean skipped;
+    private boolean dirty;
 
     void setVirtual(boolean virtual) {
         this.virtual = virtual;

--- a/src/templates/java/TokenSource.java.ftl
+++ b/src/templates/java/TokenSource.java.ftl
@@ -61,7 +61,8 @@ abstract public class TokenSource implements CharSequence
     // The starting line and column, usually 1,1
     // that is used to report a file position 
     // in 1-based line/column terms
-    private int startingLine, startingColumn;
+    private int startingLine;
+    private int startingColumn;
 
     /**
      * Set the starting line/column for location reporting.
@@ -220,7 +221,7 @@ abstract public class TokenSource implements CharSequence
     protected final void setIgnoredRange(int begin, int end) {
         for (int offset = begin; offset < end; offset++) {
            tokenLocationTable[offset] = IGNORED;
-           tokenOffsets.clear(begin,end);
+           tokenOffsets.clear(begin, end);
         }
     }
 
@@ -301,9 +302,9 @@ abstract public class TokenSource implements CharSequence
      * @param parsedLines a #java.util.BitSet that holds which lines
      * are parsed (i.e. not ignored)
      */
-    public void setParsedLines(BitSet parsedLines) {setParsedLines(parsedLines,false);}
+    public void setParsedLines(BitSet parsedLines) {setParsedLines(parsedLines, false);}
 
-    public void setUnparsedLines(BitSet unparsedLines) {setParsedLines(unparsedLines,true);}
+    public void setUnparsedLines(BitSet unparsedLines) {setParsedLines(unparsedLines, true);}
 [/#if]    
 
     // Just use the canned binary search to check whether the char
@@ -356,10 +357,10 @@ abstract public class TokenSource implements CharSequence
         int bsearchResult = Arrays.binarySearch(lineOffsets, pos);
         if (bsearchResult>=0) {
         [#-- REVISIT --]
-            return Math.max(startingLine,startingLine + bsearchResult);
+            return Math.max(startingLine, startingLine + bsearchResult);
         }
         [#-- REVISIT --]
-        return Math.max(startingLine,startingLine-(bsearchResult+2));
+        return Math.max(startingLine, startingLine -(bsearchResult + 2));
     }
 
     private void createLineOffsetsTable() {


### PR DESCRIPTION
this was explicit not a bug. It helps developers that uses code analysis tools to see how good the quality of the generated parser-code is
closes #21 