### PR TITLE
reproducable code with LinkedHashSet and cleanup NFA names

### DIFF
--- a/src/java/org/congocc/app/AppSettings.java
+++ b/src/java/org/congocc/app/AppSettings.java
@@ -30,7 +30,7 @@ public class AppSettings {
     private Path outputDir, filename, includedFileDirectory;
     private String codeLang, parserPackage, parserClassName, lexerClassName, baseName, baseNodeClassName, baseTokenClassName;
 
-    private Set<String> usedIdentifiers = new HashSet<>();
+    private Set<String> usedIdentifiers = new LinkedHashSet<>();
     private Set<String> tokensOffByDefault = new LinkedHashSet<>();
     private Map<String, String> extraTokens = new LinkedHashMap<>();
     private boolean ignoreCase, quiet;

--- a/src/java/org/congocc/app/Main.java
+++ b/src/java/org/congocc/app/Main.java
@@ -122,7 +122,7 @@ public final class Main {
     };
 
     static void usage() {
-        ArrayList<String> validChoices = new ArrayList<>(Arrays.asList(otherSupportedLanguages));
+        List<String> validChoices = new ArrayList<>(Arrays.asList(otherSupportedLanguages));
         validChoices.add(0, "java");
         StringBuilder sb = new StringBuilder();
         int n = validChoices.size();

--- a/src/java/org/congocc/codegen/FilesGenerator.java
+++ b/src/java/org/congocc/codegen/FilesGenerator.java
@@ -28,8 +28,8 @@ public class FilesGenerator {
     private final AppSettings appSettings;
     private final Errors errors;
     private final CodeInjector codeInjector;
-    private final Set<String> tokenSubclassFileNames = new HashSet<>();
-    private final HashMap<String, String> superClassLookup = new HashMap<>();
+    private final Set<String> tokenSubclassFileNames = new LinkedHashSet<>();
+    private final Map<String, String> superClassLookup = new HashMap<>();
     private final String codeLang;
     private final boolean generateRootApi;
 
@@ -148,7 +148,7 @@ public class FilesGenerator {
         generate(null, outputFile);
     }
 
-    private final Set<String> nonNodeNames = new HashSet<String>() {
+    private final Set<String> nonNodeNames = new LinkedHashSet<String>() {
         {
             add("ParseException.java");
             add("ParsingProblem.java");
@@ -193,7 +193,7 @@ public class FilesGenerator {
     public void generate(String nodeName, Path outputFile) throws IOException {
         String currentFilename = outputFile.getFileName().toString();
         String templateName = getTemplateName(currentFilename);
-        HashMap<String, Object> dataModel = new HashMap<>();
+        Map<String, Object> dataModel = new HashMap<>();
         dataModel.put("filename", currentFilename);
         dataModel.put("isAbstract", grammar.nodeIsAbstract(nodeName));
         dataModel.put("isInterface", grammar.nodeIsInterface(nodeName));

--- a/src/java/org/congocc/codegen/Sequencer.java
+++ b/src/java/org/congocc/codegen/Sequencer.java
@@ -2,16 +2,17 @@ package org.congocc.codegen;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class Sequencer {
-    private HashSet<String> nodes = new HashSet<>();
-    private HashMap<String, HashSet<String>> preds = new HashMap<>();
-    private HashMap<String, HashSet<String>> succs = new HashMap<>();
+    private Set<String> nodes = new LinkedHashSet<>();
+    private Map<String, Set<String>> preds = new HashMap<>();
+    private Map<String, Set<String>> succs = new HashMap<>();
 
-    private static HashSet<String> EMPTY_SET = new HashSet<>();
+    private static Set<String> EMPTY_SET = new LinkedHashSet<>();
 
     public void addNode(String node) {
         nodes.add(node);
@@ -31,12 +32,12 @@ public class Sequencer {
                 remove(node, s);
             }
             // remove empties
-            for (Map.Entry<String, HashSet<String>> entry : preds.entrySet()) {
+            for (Map.Entry<String, Set<String>> entry : preds.entrySet()) {
                 if (entry.getValue().isEmpty()) {
                     preds.remove(entry.getKey());
                 }
             }
-            for (Map.Entry<String, HashSet<String>> entry : succs.entrySet()) {
+            for (Map.Entry<String, Set<String>> entry : succs.entrySet()) {
                 if (entry.getValue().isEmpty()) {
                     succs.remove(entry.getKey());
                 }
@@ -45,18 +46,18 @@ public class Sequencer {
     }
 
     public void add(String pred, String succ) {
-        HashSet<String> set;
+        Set<String> set;
 
         if (pred.equals(succ)) {
             throw new IllegalArgumentException(String.format("predecessor & successor can't be the same: %s", pred));
         }
         if ((set = preds.get(succ)) == null) {
-            set = new HashSet<>();
+            set = new LinkedHashSet<>();
             preds.put(succ, set);
         }
         set.add(pred);
         if ((set = succs.get(pred)) == null) {
-            set = new HashSet<>();
+            set = new LinkedHashSet<>();
             succs.put(pred, set);
         }
         set.add(succ);
@@ -66,8 +67,8 @@ public class Sequencer {
         if (pred.equals(succ)) {
             throw new IllegalArgumentException(String.format("predecessor & successor can't be the same: %s", pred));
         }
-        HashSet<String> p = preds.get(succ);
-        HashSet<String> s = succs.get(pred);
+        Set<String> p = preds.get(succ);
+        Set<String> s = succs.get(pred);
         if ((p == null) || (s == null)) {
             throw new IllegalArgumentException(String.format("Not a successor of anything: %s", succ));
         }
@@ -82,7 +83,7 @@ public class Sequencer {
     public List<String> steps(String upto) {
         List<String> result = new ArrayList<>();
         List<String> todo = new ArrayList<>();
-        HashSet<String> seen = new HashSet<>();
+        Set<String> seen = new LinkedHashSet<>();
 
         todo.add(upto);
         while (!todo.isEmpty()) {
@@ -96,7 +97,7 @@ public class Sequencer {
             else {
                 seen.add(step);
                 result.add(step);
-                HashSet<String> p = preds.getOrDefault(step, EMPTY_SET);
+                Set<String> p = preds.getOrDefault(step, EMPTY_SET);
                 todo.addAll(p);
             }
         }

--- a/src/java/org/congocc/codegen/TemplateGlobals.java
+++ b/src/java/org/congocc/codegen/TemplateGlobals.java
@@ -193,7 +193,7 @@ public class TemplateGlobals {
         }
         List<String> sorted = seq.steps("Token");
         sorted.remove(0);
-        HashMap<String, Object> result = new HashMap<>();
+        Map<String, Object> result = new HashMap<>();
         result.put("sortedNames", sorted);
         result.put("tokenClassMap", tokenClassMap);
         return result;

--- a/src/java/org/congocc/codegen/Translator.java
+++ b/src/java/org/congocc/codegen/Translator.java
@@ -24,7 +24,7 @@ public class Translator {
     protected String currentClass;
 
     public static <T> Set<T> makeSet(T... objs) {
-        Set<T> set = new HashSet<>();
+        Set<T> set = new LinkedHashSet<>();
         Collections.addAll(set, objs);
         return set;
     }
@@ -598,7 +598,7 @@ public class Translator {
 
         private void addAnnotation(String annotation) {
             if (annotations == null) {
-                annotations = new HashSet<>();
+                annotations = new LinkedHashSet<>();
             }
             annotations.add(annotation);
         }
@@ -660,7 +660,7 @@ public class Translator {
     protected Map<String, ASTTypeExpression> properties = new HashMap<>();
     protected SymbolTable fields = new SymbolTable();
     protected Map<String, Set<String>> propertyMap = new HashMap<>();
-    protected Set<String> parameterNames = new HashSet<>();
+    protected Set<String> parameterNames = new LinkedHashSet<>();
 
     public void clearFields() { fields.clear(); properties.clear(); }
 
@@ -776,7 +776,7 @@ public class Translator {
         return (idx < n) && Character.isUpperCase(name.charAt(idx));
     }
 
-    protected Set<String> notSetters = new HashSet<>(Arrays.asList("setLineSkipped"));
+    protected Set<String> notSetters = new LinkedHashSet<>(Arrays.asList("setLineSkipped"));
 
     public boolean isSetter(String name) {
         if ((name.length() <= 3) || !name.startsWith("set") || notSetters.contains(name)) {
@@ -1834,9 +1834,9 @@ public class Translator {
         return result;
     }
 
-    protected HashMap<String, Set<String>> nestedDeclarations;
+    protected Map<String, Set<String>> nestedDeclarations;
 
-    public HashMap<String, Set<String>> getNestedDeclarations() {
+    public Map<String, Set<String>> getNestedDeclarations() {
         return nestedDeclarations;
     }
 
@@ -1846,7 +1846,7 @@ public class Translator {
         }
         Set<String> existing = nestedDeclarations.get(currentClass);
         if (existing == null) {
-            existing = new HashSet<>();
+            existing = new LinkedHashSet<>();
             nestedDeclarations.put(currentClass, existing);
         }
         existing.add(name);

--- a/src/java/org/congocc/codegen/csharp/CSharpTranslator.java
+++ b/src/java/org/congocc/codegen/csharp/CSharpTranslator.java
@@ -19,7 +19,7 @@ public class CSharpTranslator extends Translator {
         return operator;
     }
 
-    private static final Set<String> specialPrefixes = new HashSet<>();
+    private static final Set<String> specialPrefixes = new LinkedHashSet<>();
 
     private static boolean isSpecialPrefix(String ident) {
         boolean result = false;
@@ -416,10 +416,10 @@ public class CSharpTranslator extends Translator {
         }
     }
 
-    protected static final HashSet<String> accessModifiers = new HashSet<>(Arrays.asList("public", "protected", "private"));
+    protected static final HashSet<String> accessModifiers = new LinkedHashSet<>(Arrays.asList("public", "protected", "private"));
 
     protected void translateModifiers(List<String> modifiers, StringBuilder result) {
-        HashSet<String> mods = new HashSet<>(modifiers);
+        Set<String> mods = new LinkedHashSet<>(modifiers);
         List<String> translated_mods = new ArrayList<>();
         boolean accessModifierAdded = false;
 
@@ -924,7 +924,7 @@ public class CSharpTranslator extends Translator {
             throw new UnsupportedOperationException();
         }
         javaName = javaName.substring(prefix.length());
-        ArrayList<String> parts = new ArrayList<>(Arrays.asList(javaName.split("\\.")));
+        List<String> parts = new ArrayList<>(Arrays.asList(javaName.split("\\.")));
         int n = parts.size();
         String aliasName = null;
         for (int i = 0; i < n; i++) {

--- a/src/java/org/congocc/codegen/java/CodeInjector.java
+++ b/src/java/org/congocc/codegen/java/CodeInjector.java
@@ -20,9 +20,9 @@ public class CodeInjector {
     private final Map<String, List<ObjectType>> implementsLists = new HashMap<>();
     private final Map<String, TypeParameters> typeParameterLists = new HashMap<>();
     private final Map<String, List<ClassOrInterfaceBodyDeclaration>> bodyDeclarations = new HashMap<>();
-    private final Set<String> overriddenMethods = new HashSet<>();  // Not presently queried ...
-    private final Set<String> typeNames = new HashSet<>();
-    private final Set<String> interfaces = new HashSet<>();  // Not presently queried ...
+    private final Set<String> overriddenMethods = new LinkedHashSet<>();  // Not presently queried ...
+    private final Set<String> typeNames = new LinkedHashSet<>();
+    private final Set<String> interfaces = new LinkedHashSet<>();  // Not presently queried ...
     private final Grammar grammar;
     private AppSettings appSettings;
     
@@ -163,7 +163,7 @@ public class CodeInjector {
 
     public void injectCode(CompilationUnit jcu) {
         String packageName = jcu.getPackageName();
-        Set<ImportDeclaration> allInjectedImports = new HashSet<>();
+        Set<ImportDeclaration> allInjectedImports = new LinkedHashSet<>();
         for (TypeDeclaration typeDecl : jcu.getTypeDeclarations()) {
             String fullName = typeDecl.getName();
             if (packageName !=null) {

--- a/src/java/org/congocc/codegen/java/Reaper.java
+++ b/src/java/org/congocc/codegen/java/Reaper.java
@@ -18,10 +18,10 @@ import static org.congocc.parser.Token.TokenType.*;
  * in inner classes, but we don't bother about that either.
  */
 class Reaper extends Node.Visitor {
-    private Set<String> usedMethodNames = new HashSet<>();
-    private Set<String> usedTypeNames = new HashSet<>();
-    private Set<String> usedVarNames = new HashSet<>();
-    private Set<String> usedImportDeclarations = new HashSet<>();
+    private Set<String> usedMethodNames = new LinkedHashSet<>();
+    private Set<String> usedTypeNames = new LinkedHashSet<>();
+    private Set<String> usedVarNames = new LinkedHashSet<>();
+    private Set<String> usedImportDeclarations = new LinkedHashSet<>();
     private CompilationUnit jcu;
     private boolean onSecondPass;
 
@@ -175,7 +175,7 @@ class Reaper extends Node.Visitor {
     // is not in usedVarNames. The only complicated case is if the field
     // has more than one variable declaration comma-separated
     private void stripUnusedVars(FieldDeclaration fd) {
-        Set<Node> toBeRemoved = new HashSet<Node>();
+        Set<Node> toBeRemoved = new LinkedHashSet<Node>();
         for (VariableDeclarator vd : fd.childrenOfType(VariableDeclarator.class)) {
             if (!usedVarNames.contains(vd.getName())) {
                 toBeRemoved.add(vd);

--- a/src/java/org/congocc/codegen/python/PythonTranslator.java
+++ b/src/java/org/congocc/codegen/python/PythonTranslator.java
@@ -35,7 +35,7 @@ public class PythonTranslator extends Translator {
         return result;
     }
 
-    private static final Set<String> specialPrefixes = new HashSet<>();
+    private static final Set<String> specialPrefixes = new LinkedHashSet<>();
 
     private static boolean isSpecialPrefix(String ident) {
         boolean result = false;
@@ -272,7 +272,7 @@ public class PythonTranslator extends Translator {
         }
     }
 
-    protected static Set<String> leaveAsMethods = new HashSet<>(Arrays.asList("getIndents", "isConstant"));
+    protected static Set<String> leaveAsMethods = new LinkedHashSet<>(Arrays.asList("getIndents", "isConstant"));
 
     protected boolean treatAsProperty(String methodName) {
         return isGetter(methodName) || methodName.equals("previousCachedToken");

--- a/src/java/org/congocc/core/Expansion.java
+++ b/src/java/org/congocc/core/Expansion.java
@@ -359,7 +359,7 @@ abstract public class Expansion extends BaseNode {
      */
     final public int getMaximumSize() {
         if (maxSize == -1) {
-            maxSize = getMaximumSize(new HashSet<>());
+            maxSize = getMaximumSize(new LinkedHashSet<>());
         }
         return maxSize;
     }
@@ -369,7 +369,7 @@ abstract public class Expansion extends BaseNode {
      */
     final public int getMinimumSize() {
         if (minSize == -1) {
-            minSize = getMinimumSize(new HashSet<>());
+            minSize = getMinimumSize(new LinkedHashSet<>());
         }
         return minSize;
     }
@@ -495,7 +495,7 @@ abstract public class Expansion extends BaseNode {
     }
 
     final public boolean potentiallyStartsWith(String productionName) {
-        return potentiallyStartsWith(productionName, new HashSet<>());
+        return potentiallyStartsWith(productionName, new LinkedHashSet<>());
     }
 
     /*

--- a/src/java/org/congocc/core/Grammar.java
+++ b/src/java/org/congocc/core/Grammar.java
@@ -33,8 +33,8 @@ public class Grammar extends BaseNode {
     private Map<String,String> nodeClassNames = new HashMap<>();
     // TODO use these later for Nodes that correspond to abstract
     // classes or interfaces
-    private Set<String> abstractNodeNames = new HashSet<>();
-    private Set<String> interfaceNodeNames = new HashSet<>();
+    private Set<String> abstractNodeNames = new LinkedHashSet<>();
+    private Set<String> interfaceNodeNames = new LinkedHashSet<>();
     private Map<String, String> nodePackageNames = new HashMap<>();
     private List<Node> codeInjections = new ArrayList<>();
     private List<String> lexerTokenHooks = new ArrayList<>(),
@@ -44,7 +44,7 @@ public class Grammar extends BaseNode {
                          resetTokenHooks = new ArrayList<>();
     private Map<String, List<String>> closeNodeHooksByClass = new HashMap<>();
 
-    private Set<Path> alreadyIncluded = new HashSet<>();
+    private Set<Path> alreadyIncluded = new LinkedHashSet<>();
 
     private TemplateGlobals templateGlobals;
     private AppSettings appSettings;
@@ -198,7 +198,7 @@ public class Grammar extends BaseNode {
     }
 
     public List<Expansion> getExpansionsNeedingRecoverMethod() {
-        Set<String> alreadyAdded = new HashSet<>();
+        Set<String> alreadyAdded = new LinkedHashSet<>();
         List<Expansion> result = new ArrayList<>();
         for (Expansion exp : descendants(Expansion.class, Expansion::getRequiresRecoverMethod)) {
             String methodName = exp.getRecoverMethodName();
@@ -281,7 +281,7 @@ public class Grammar extends BaseNode {
     }
 
     private List<Expansion> getExpansionsForSet(int type) {
-        HashSet<String> usedNames = new HashSet<>();
+        Set<String> usedNames = new LinkedHashSet<>();
         List<Expansion> result = new ArrayList<>();
         for (Expansion expansion : descendants(Expansion.class)) {
             if (expansion.getParent() instanceof BNFProduction) continue; // Handle these separately

--- a/src/java/org/congocc/core/LexerData.java
+++ b/src/java/org/congocc/core/LexerData.java
@@ -20,7 +20,7 @@ public class LexerData {
     private List<RegularExpression> regularExpressions = new ArrayList<>();
 
     private Map<String, RegularExpression> namedTokensTable = new HashMap<>();
-    private Set<RegularExpression> overriddenTokens = new HashSet<>();
+    private Set<RegularExpression> overriddenTokens = new LinkedHashSet<>();
 
     public LexerData(Grammar grammar) {
         this.grammar = grammar;
@@ -145,7 +145,7 @@ public class LexerData {
     }
 
     public Set<String> getTokenNames() {
-        Set<String> result = new HashSet<>();
+        Set<String> result = new LinkedHashSet<>();
         for (RegularExpression regexp : regularExpressions) {
             result.add(regexp.getLabel());
         }
@@ -320,7 +320,7 @@ public class LexerData {
      */
     class RegexpVisitor extends Node.Visitor {
 
-        private HashSet<RegularExpression> alreadyVisited = new HashSet<>(), currentlyVisiting = new HashSet<>();
+        private HashSet<RegularExpression> alreadyVisited = new LinkedHashSet<>(), currentlyVisiting = new LinkedHashSet<>();
 
         void visit(RegexpRef ref) {
             RegularExpression referredTo = ref.getRegexp();

--- a/src/java/org/congocc/core/nfa/CompositeStateSet.java
+++ b/src/java/org/congocc/core/nfa/CompositeStateSet.java
@@ -26,8 +26,8 @@ public class CompositeStateSet {
     public String getMethodName() {
         String lexicalStateName = lexicalState.getName();
         if (lexicalStateName.equals("DEFAULT")) 
-            return "NFA_" + index;
-        return "NFA_" + lexicalStateName + "_" + index; 
+            return "NfaIndex" + index;
+        return "NfaName" + lexicalStateName + "Index" + index; 
     }
 
     public boolean equals(Object other) {

--- a/src/java/org/congocc/core/nfa/CompositeStateSet.java
+++ b/src/java/org/congocc/core/nfa/CompositeStateSet.java
@@ -10,12 +10,12 @@ import java.util.*;
  * XXXNfaData::NfaFunction functional interface. 
  */
 public class CompositeStateSet {
-    private Set<NfaState> states = new HashSet<>();
+    private Set<NfaState> states = new LinkedHashSet<>();
     final LexicalStateData lexicalState;
     int index=-1; 
 
     CompositeStateSet(Set<NfaState> states, LexicalStateData lsd) {
-        this.states = new HashSet<>(states);
+        this.states = new LinkedHashSet<>(states);
         this.lexicalState = lsd;
     }
 
@@ -43,7 +43,7 @@ public class CompositeStateSet {
      * @return sorted list of states
      */
     public List<NfaState> getOrderedStates() {
-        ArrayList<NfaState> result = new ArrayList<>(states);
+        List<NfaState> result = new ArrayList<>(states);
         Collections.sort(result, CompositeStateSet::nfaComparator);
         return result;    
     }

--- a/src/java/org/congocc/core/nfa/LexicalStateData.java
+++ b/src/java/org/congocc/core/nfa/LexicalStateData.java
@@ -23,11 +23,11 @@ public class LexicalStateData {
     private Map<String, RegexpStringLiteral> caseSensitiveTokenTable = new HashMap<>();
     private Map<String, RegexpStringLiteral> caseInsensitiveTokenTable = new HashMap<>();
 
-    private Set<RegularExpression> regularExpressions = new HashSet<>();
+    private Set<RegularExpression> regularExpressions = new LinkedHashSet<>();
 
     private NfaState initialState;
 
-    private Set<NfaState> allStates = new HashSet<>();
+    private Set<NfaState> allStates = new LinkedHashSet<>();
 
     private Errors errors;
     
@@ -98,7 +98,7 @@ public class LexicalStateData {
     }
 
     private void generateData() {
-        Set<NfaState> alreadyVisited = new HashSet<>();
+        Set<NfaState> alreadyVisited = new LinkedHashSet<>();
         for (NfaState state: allStates) {
             state.doEpsilonClosure(alreadyVisited);
         }
@@ -108,9 +108,9 @@ public class LexicalStateData {
             state.setMovesArrayName(simpleStates.size());
             simpleStates.add(state);
         }
-        Set<CompositeStateSet> allComposites = new HashSet<>();
+        Set<CompositeStateSet> allComposites = new LinkedHashSet<>();
         CompositeStateSet initialComposite = initialState.getComposite();
-        initialComposite.findWhatIsUsed(new HashSet<>(), allComposites);
+        initialComposite.findWhatIsUsed(new LinkedHashSet<>(), allComposites);
         this.compositeSets = new ArrayList<>(allComposites);
         // Make sure the initial state is the first in the list.
         int indexInList = compositeSets.indexOf(initialComposite);

--- a/src/java/org/congocc/core/nfa/NfaState.java
+++ b/src/java/org/congocc/core/nfa/NfaState.java
@@ -13,7 +13,7 @@ public class NfaState {
     final LexicalStateData lexicalState;
     private RegularExpression type;
     private NfaState nextState;
-    private Set<NfaState> epsilonMoves = new HashSet<>();
+    private Set<NfaState> epsilonMoves = new LinkedHashSet<>();
     private String movesArrayName;
 
     // An ordered list of the ranges of characters that this 

--- a/src/templates/java/NfaCode.java.ftl
+++ b/src/templates/java/NfaCode.java.ftl
@@ -23,7 +23,7 @@
     [/#if] 
     {
     [#list lexicalState.canonicalSets as state]
-      ${lexicalState.name}::${state.methodName}
+      ${lexicalState.name}::get${state.methodName}
       [#if state_has_next],[/#if]
     [/#list]
     };
@@ -60,7 +60,7 @@
    that correspond to an instanceof org.congocc.core.CompositeStateSet
 --]
 [#macro GenerateNfaMethod nfaState]  
-    private static TokenType ${nfaState.methodName}(int ch, BitSet nextStates, EnumSet<TokenType> validTypes) {
+    private static TokenType get${nfaState.methodName}(int ch, BitSet nextStates, EnumSet<TokenType> validTypes) {
       TokenType type = null;
     [#var states = nfaState.orderedStates, lastBlockStartIndex=0]
     [#list states as state]


### PR DESCRIPTION
reproducible :
use orderd LinkedHashSet and Interfaces where possible

checked against the generated file in build:
/examples/java/org/parsers/java/JavaLexer.java

NFA names:
does not change the behavior of the code in any way. generated only cleaner method-names in java code.