### PR TITLE
Add experimental option(s) for JTB-compatible tree

### DIFF
--- a/src/grammars/CongoCC.ccc
+++ b/src/grammars/CongoCC.ccc
@@ -897,7 +897,7 @@ GrammarInclusion throws IOException :
    }
 ;
 
-CodeInjection :
+#CodeInjection :
 {
     boolean isInterface = false;
     Annotation annotation = null;
@@ -950,12 +950,14 @@ CodeInjection :
                 if (enterIncludes) {
                     grammar.addCodeInjection(CURRENT_NODE);
                 }
+                return CURRENT_NODE;
         }
 ;
 
 INJECT CodeInjection : 
    import java.util.List;
    import java.util.ArrayList;
+   import org.congocc.core.Grammar;
 {
    public String name;
    public List<ImportDeclaration> importDeclarations = new ArrayList<ImportDeclaration>();
@@ -963,10 +965,27 @@ INJECT CodeInjection :
    public List<ObjectType> extendsList = new ArrayList<>();
    public List<ObjectType> implementsList = new ArrayList<>();
    public ClassOrInterfaceBody body; 
-   public boolean isInterface;   
+   public boolean isInterface;
+   
+   public static void inject(Grammar grammar, String nodeName, String injection) {
+        String inject = "INJECT " + nodeName + " : " + injection;
+        CongoCCParser parser;
+        try {
+            parser = new CongoCCParser(grammar, "dynamicInjection", inject);
+            parser.setEnterIncludes(true);
+            CodeInjection ci = parser.CodeInjection();
+            grammar.getInjector().add(ci);
+        } catch (Exception e) {
+            //FIXME: need something better here!
+            System.err.println("parser exception: " + e.getLocalizedMessage());
+        } finally {
+            parser = null;
+        }        
+   }
 
    public void addExtendsType(ObjectType type) {extendsList.add(type);}
    public void addImplementsType(ObjectType type) {implementsList.add(type);}
+   
 }
 
 CodeInjection2 :
@@ -1470,8 +1489,10 @@ ExpansionWithParentheses :
 
 
 INJECT ExpansionWithParentheses : 
-   import org.congocc.core.*;
+   import org.congocc.core.*; 
+   import org.congocc.core.ExpansionSequence.*;
    extends ExpansionWithNested
+   implements SyntaxElement
 {
     @Override 
     public String getSpecifiedLexicalState() {
@@ -1834,8 +1855,10 @@ Terminal# :
 
 INJECT Terminal :
    import org.congocc.core.*;
+   import org.congocc.core.ExpansionSequence.*;
    import java.util.Set;
    extends Expansion
+   implements SyntaxElement
 {
     @Property RegularExpression regexp;
     @Property Name lhs;

--- a/src/java/org/congocc/app/AppSettings.java
+++ b/src/java/org/congocc/app/AppSettings.java
@@ -46,13 +46,13 @@ public class AppSettings {
                                     + "NODE_USES_PARSER,TREE_BUILDING_DEFAULT,TREE_BUILDING_ENABLED,TOKENS_ARE_NODES," 
                                     + "SPECIAL_TOKENS_ARE_NODES,UNPARSED_TOKENS_ARE_NODES,FREEMARKER_NODES," 
                                     + "TOKEN_MANAGER_USES_PARSER,ENSURE_FINAL_EOL,MINIMAL_TOKEN,C_CONTINUATION_LINE," 
-                                    + "USE_CHECKED_EXCEPTION,LEGACY_GLITCHY_LOOKAHEAD,TOKEN_CHAINING,USES_PREPROCESSOR,";
+                                    + "USE_CHECKED_EXCEPTION,LEGACY_GLITCHY_LOOKAHEAD,TOKEN_CHAINING,USES_PREPROCESSOR,X_JTB_PARSE_TREE,X_SYNTACTIC_NODES_ENABLED,";
 
     private String stringSettings = ",BASE_NAME,PARSER_PACKAGE,PARSER_CLASS,LEXER_CLASS,BASE_SRC_DIR,BASE_NODE_CLASS," 
                                     + "BASE_TOKEN_CLASS,NODE_PREFIX,NODE_CLASS,NODE_PACKAGE,DEFAULT_LEXICAL_STATE," 
                                     + "NODE_CLASS,OUTPUT_DIRECTORY,DEACTIVATE_TOKENS,EXTRA_TOKENS,ROOT_API_PACKAGE," 
                                     + "COPYRIGHT_BLURB,TERMINATING_STRING,";
-                                    
+
     private String integerSettings = ",TAB_SIZE,TABS_TO_SPACES,JDK_TARGET,";
 
     private static Map<String, String> locationAliases = new HashMap<String, String>() {
@@ -136,6 +136,13 @@ public class AppSettings {
             }
             if (settings.get("NODE_USES_PARSER") != null) {
                 errors.addWarning(null, msg.replace("OPTION_NAME", "NODE_USES_PARSER"));
+            }
+            if (settings.get("X_SYNTACTIC_NODES_ENABLED") != null) {
+                errors.addWarning(null, msg.replace("OPTION_NAME", "X_SYNTACTIC_NODES_ENABLED"));
+                if (settings.get("X_JTB_PARSE_TREE") != null) {
+                    errors.addWarning(null, msg.replace("OPTION_NAME", "X_JTB_PARSE_TREE")
+                    		         .replace("TREE_BUILDING_ENABLED", "X_SYNTACTIC_NODES_ENABLED"));
+                }
             }
         }
     }
@@ -490,6 +497,16 @@ public class AppSettings {
 
     public boolean getNodeUsesParser() {
         Boolean b = (Boolean) settings.get("NODE_USES_PARSER");
+        return b != null && b;
+    }
+
+    public boolean getJtbParseTree() {
+        Boolean b = (Boolean) settings.get("X_JTB_PARSE_TREE");
+        return b != null && b;
+    }
+
+    public boolean getSyntacticNodesEnabled() {
+        Boolean b = (Boolean) settings.get("X_SYNTACTIC_NODES_ENABLED");
         return b != null && b;
     }
 

--- a/src/java/org/congocc/codegen/java/CodeInjector.java
+++ b/src/java/org/congocc/codegen/java/CodeInjector.java
@@ -160,6 +160,15 @@ public class CodeInjector {
         	existingDecls.addAll(body.childrenOfType(ClassOrInterfaceBodyDeclaration.class));
         }
     }
+    
+    /**
+     * Adds a {@link CodeInjection} dynamically (post-parsing).
+     * @param ci is the {@code CodeInjection} to be added
+     */
+    public void add(CodeInjection ci) {
+        String name = ci.name;
+        add(name, ci.importDeclarations, ci.annotations, ci.extendsList, ci.implementsList, ci.body, ci.isInterface);
+    }
 
     public void injectCode(CompilationUnit jcu) {
         String packageName = jcu.getPackageName();

--- a/src/java/org/congocc/core/BNFProduction.java
+++ b/src/java/org/congocc/core/BNFProduction.java
@@ -3,11 +3,16 @@ package org.congocc.core;
 import org.congocc.parser.Token;
 import org.congocc.parser.Token.TokenType;
 import static org.congocc.parser.Token.TokenType.*;
+
+import java.util.Set;
+
 import org.congocc.parser.tree.*;
 
-public class BNFProduction extends BaseNode {
-    private Expansion expansion, recoveryExpansion;
-    private String lexicalState, name, leadingComments = "";
+public class BNFProduction extends Expansion {
+    private Expansion expansion;
+    private Expansion recoveryExpansion;
+    private String lexicalState, name;
+    private String leadingComments = "";
     private boolean implicitReturnType;
     
     public Expansion getExpansion() {
@@ -148,4 +153,29 @@ public class BNFProduction extends BaseNode {
     public boolean isLeftRecursive() {
         return getExpansion().potentiallyStartsWith(getName());
     }
+    
+    @Override
+    public Expansion getNestedExpansion() {
+    	return expansion;
+    }
+
+	@Override
+	public TokenSet getFirstSet() {
+		return expansion.getFirstSet();
+	}
+
+	@Override
+	public TokenSet getFinalSet() {
+		return expansion.getFinalSet();
+	}
+
+	@Override
+	protected int getMinimumSize(Set<String> visitedNonTerminals) {
+		return expansion.getMinimumSize(visitedNonTerminals);
+	}
+
+	@Override
+	protected int getMaximumSize(Set<String> visitedNonTermiinals) {
+		return expansion.getMaximumSize(visitedNonTermiinals);
+	}
 }

--- a/src/java/org/congocc/core/Expansion.java
+++ b/src/java/org/congocc/core/Expansion.java
@@ -24,6 +24,7 @@ abstract public class Expansion extends BaseNode {
     }
 
     public final BNFProduction getContainingProduction() {
+    	if (this instanceof BNFProduction) return (BNFProduction) this;
         return firstAncestorOfType(BNFProduction.class);
     }
 
@@ -57,13 +58,11 @@ abstract public class Expansion extends BaseNode {
         return null;
     }
 
-    public TreeBuildingAnnotation getTreeNodeBehavior() {
-        if (treeNodeBehavior == null) {
-            if (this.getParent() instanceof BNFProduction) {
-                return ((BNFProduction) getParent()).getTreeNodeBehavior();
-            }
+    public TreeBuildingAnnotation getTreeNodeBehavior() { //NOTE: removed "pull-down" of BNFProduction TBA
+        if (this.getParent() instanceof ExpansionWithParentheses) {
+            return null;
         }
-        return treeNodeBehavior;
+    	return treeNodeBehavior;
     }
 
     public void setTreeNodeBehavior(TreeBuildingAnnotation treeNodeBehavior) {

--- a/src/java/org/congocc/core/ExpansionSequence.java
+++ b/src/java/org/congocc/core/ExpansionSequence.java
@@ -5,6 +5,12 @@ import org.congocc.parser.Node;
 import org.congocc.parser.tree.*;
 
 public class ExpansionSequence extends Expansion {
+	
+	/**
+	 * A marker interface in order to enumerate syntax element units within a sequence.
+	 *
+	 */
+	public interface SyntaxElement extends Node {}
 
     /**
      * @return a List that includes child expansions that are
@@ -19,6 +25,10 @@ public class ExpansionSequence extends Expansion {
             } 
         }
         return result;
+    }
+    
+    public int getNumberOfSyntaxElements() {
+    	return childrenOfType(SyntaxElement.class).size();
     }
 
     Expansion firstNonEmpty() {

--- a/src/java/org/congocc/core/Grammar.java
+++ b/src/java/org/congocc/core/Grammar.java
@@ -284,7 +284,7 @@ public class Grammar extends BaseNode {
         Set<String> usedNames = new LinkedHashSet<>();
         List<Expansion> result = new ArrayList<>();
         for (Expansion expansion : descendants(Expansion.class)) {
-            if (expansion.getParent() instanceof BNFProduction) continue; // Handle these separately
+            if ((expansion instanceof BNFProduction) || (expansion.getParent() instanceof BNFProduction)) continue; // Handle these separately
             if (type == 0 || type == 2) {   // follow sets
                 if (expansion instanceof CodeBlock) {
                     continue;
@@ -431,6 +431,17 @@ public class Grammar extends BaseNode {
     public void addCodeInjection(Node n) {
         checkForHooks(n, null);
         codeInjections.add(n);
+    }
+    
+    /**
+     * Adds an injected field to the specified {@link Node} dynamically (post parsing).
+     * @param nodeName is the name of the {@code Node}
+     * @param modifiers is the string of modifiers needed (if any)
+     * @param className is the type of the field
+     * @param fieldName is the name of the field to be injected
+     */
+    public void addFieldInjection(String nodeName, String modifiers, String className, String fieldName) {
+    	CodeInjection.inject(this, nodeName, "{" + modifiers + " " + className + " " + fieldName + ";}");
     }
 
     public boolean isInInclude() {

--- a/src/java/org/congocc/core/NonTerminal.java
+++ b/src/java/org/congocc/core/NonTerminal.java
@@ -1,10 +1,11 @@
 package org.congocc.core;
 
+import org.congocc.core.ExpansionSequence.SyntaxElement;
 import org.congocc.parser.Token.TokenType;
 import org.congocc.parser.tree.*;
 import java.util.Set;
 
-public class NonTerminal extends Expansion {
+public class NonTerminal extends Expansion implements SyntaxElement {
     
     private Name LHS;
     public Name getLHS() {return LHS;}


### PR DESCRIPTION
Many changes to ParserProductions template to implement JTB option, make BNFProduction an Expansion, and add "dynamic" injection to add JTB fields to generated nodes.  

This is not all that is needed to "finish" this capability, but it is the hard part, I hope.  As it stands, I believe it does not affect any current behavior when the option(s) is off.  Note there are 2 "X_..." options that both have to be set to achieve the JTB behavior.  I suspect this will become one option at some point, but I have a reason to keep them separate at the moment.  Also at the moment, the JTB tree requires a set of Productions/INJECTIONs in the (user's) parser.ccc to create the syntactic nodes and provide the equivalent JTB nodes for them to extend, but the end-game is probably to generate them without that requirement.

At this point I'm in the process of validating that the tree produced by this is functionally identical to the JTB/Javacc tree for all of the sources I have at my disposal.  It is turning out to be some work because, while I thought I had not made many changed that would affect the tree structure while getting the congo-based grammar correct, it turns out I made more than I remembered.  For all of those I have to run my checker which will identify the first node conflict it encounters, and then try and change the Javacc version of the grammar to have the same structure as the new congo version, without running into javacc lookahead failures due to the changed structure.  It is labor-intensive.

I did this PR so that you could have a chance to tell me if there is a better way you want me to do something. I have not paid any attention to Python and CSharp (yet?), as is obvious.  While they would have no need to the JTB option per se, I am assuming the major changes to the ParserProductions template, for example, should be aligned for future maintenance.  