### PR TITLE
Prepare for JTB feature enhancement

### DIFF
--- a/src/grammars/CongoCC.ccc
+++ b/src/grammars/CongoCC.ccc
@@ -897,7 +897,7 @@ GrammarInclusion throws IOException :
    }
 ;
 
-CodeInjection :
+#CodeInjection :
 {
     boolean isInterface = false;
     Annotation annotation = null;
@@ -950,12 +950,14 @@ CodeInjection :
                 if (enterIncludes) {
                     grammar.addCodeInjection(CURRENT_NODE);
                 }
+                return CURRENT_NODE;
         }
 ;
 
 INJECT CodeInjection : 
    import java.util.List;
    import java.util.ArrayList;
+   import org.congocc.core.Grammar;
 {
    public String name;
    public List<ImportDeclaration> importDeclarations = new ArrayList<ImportDeclaration>();
@@ -963,10 +965,27 @@ INJECT CodeInjection :
    public List<ObjectType> extendsList = new ArrayList<>();
    public List<ObjectType> implementsList = new ArrayList<>();
    public ClassOrInterfaceBody body; 
-   public boolean isInterface;   
+   public boolean isInterface;
+   
+   public static void inject(Grammar grammar, String nodeName, String injection) {
+        String inject = "INJECT " + nodeName + " : " + injection;
+        CongoCCParser parser;
+        try {
+            parser = new CongoCCParser(grammar, "dynamicInjection", inject);
+            parser.setEnterIncludes(true);
+            CodeInjection ci = parser.CodeInjection();
+            grammar.getInjector().add(ci);
+        } catch (Exception e) {
+            //FIXME: need something better here!
+            System.err.println("parser exception: " + e.getLocalizedMessage());
+        } finally {
+            parser = null;
+        }        
+   }
 
    public void addExtendsType(ObjectType type) {extendsList.add(type);}
    public void addImplementsType(ObjectType type) {implementsList.add(type);}
+   
 }
 
 CodeInjection2 :
@@ -1470,8 +1489,10 @@ ExpansionWithParentheses :
 
 
 INJECT ExpansionWithParentheses : 
-   import org.congocc.core.*;
+   import org.congocc.core.*; 
+   import org.congocc.core.ExpansionSequence.*;
    extends ExpansionWithNested
+   implements SyntaxElement
 {
     @Override 
     public String getSpecifiedLexicalState() {
@@ -1834,8 +1855,10 @@ Terminal# :
 
 INJECT Terminal :
    import org.congocc.core.*;
+   import org.congocc.core.ExpansionSequence.*;
    import java.util.Set;
    extends Expansion
+   implements SyntaxElement
 {
     @Property RegularExpression regexp;
     @Property Name lhs;

--- a/src/java/org/congocc/codegen/java/CodeInjector.java
+++ b/src/java/org/congocc/codegen/java/CodeInjector.java
@@ -160,6 +160,15 @@ public class CodeInjector {
         	existingDecls.addAll(body.childrenOfType(ClassOrInterfaceBodyDeclaration.class));
         }
     }
+    
+    /**
+     * Adds a {@link CodeInjection} dynamically (post-parsing).
+     * @param ci is the {@code CodeInjection} to be added
+     */
+    public void add(CodeInjection ci) {
+        String name = ci.name;
+        add(name, ci.importDeclarations, ci.annotations, ci.extendsList, ci.implementsList, ci.body, ci.isInterface);
+    }
 
     public void injectCode(CompilationUnit jcu) {
         String packageName = jcu.getPackageName();

--- a/src/java/org/congocc/core/BNFProduction.java
+++ b/src/java/org/congocc/core/BNFProduction.java
@@ -3,11 +3,16 @@ package org.congocc.core;
 import org.congocc.parser.Token;
 import org.congocc.parser.Token.TokenType;
 import static org.congocc.parser.Token.TokenType.*;
+
+import java.util.Set;
+
 import org.congocc.parser.tree.*;
 
-public class BNFProduction extends BaseNode {
-    private Expansion expansion, recoveryExpansion;
-    private String lexicalState, name, leadingComments = "";
+public class BNFProduction extends Expansion {
+    private Expansion expansion;
+    private Expansion recoveryExpansion;
+    private String lexicalState, name;
+    private String leadingComments = "";
     private boolean implicitReturnType;
     
     public Expansion getExpansion() {
@@ -148,4 +153,29 @@ public class BNFProduction extends BaseNode {
     public boolean isLeftRecursive() {
         return getExpansion().potentiallyStartsWith(getName());
     }
+    
+    @Override
+    public Expansion getNestedExpansion() {
+    	return expansion;
+    }
+
+	@Override
+	public TokenSet getFirstSet() {
+		return expansion.getFirstSet();
+	}
+
+	@Override
+	public TokenSet getFinalSet() {
+		return expansion.getFinalSet();
+	}
+
+	@Override
+	protected int getMinimumSize(Set<String> visitedNonTerminals) {
+		return expansion.getMinimumSize(visitedNonTerminals);
+	}
+
+	@Override
+	protected int getMaximumSize(Set<String> visitedNonTermiinals) {
+		return expansion.getMaximumSize(visitedNonTermiinals);
+	}
 }

--- a/src/java/org/congocc/core/Expansion.java
+++ b/src/java/org/congocc/core/Expansion.java
@@ -24,6 +24,7 @@ abstract public class Expansion extends BaseNode {
     }
 
     public final BNFProduction getContainingProduction() {
+    	if (this instanceof BNFProduction) return (BNFProduction) this;
         return firstAncestorOfType(BNFProduction.class);
     }
 
@@ -57,13 +58,11 @@ abstract public class Expansion extends BaseNode {
         return null;
     }
 
-    public TreeBuildingAnnotation getTreeNodeBehavior() {
-        if (treeNodeBehavior == null) {
-            if (this.getParent() instanceof BNFProduction) {
-                return ((BNFProduction) getParent()).getTreeNodeBehavior();
-            }
+    public TreeBuildingAnnotation getTreeNodeBehavior() { //NOTE: removed "pull-down" of BNFProduction TBA
+        if (this.getParent() instanceof ExpansionWithParentheses) {
+            return null;
         }
-        return treeNodeBehavior;
+    	return treeNodeBehavior;
     }
 
     public void setTreeNodeBehavior(TreeBuildingAnnotation treeNodeBehavior) {

--- a/src/java/org/congocc/core/ExpansionSequence.java
+++ b/src/java/org/congocc/core/ExpansionSequence.java
@@ -5,6 +5,12 @@ import org.congocc.parser.Node;
 import org.congocc.parser.tree.*;
 
 public class ExpansionSequence extends Expansion {
+	
+	/**
+	 * A marker interface in order to enumerate syntax element units within a sequence.
+	 *
+	 */
+	public interface SyntaxElement extends Node {}
 
     /**
      * @return a List that includes child expansions that are
@@ -19,6 +25,19 @@ public class ExpansionSequence extends Expansion {
             } 
         }
         return result;
+    }
+    
+    final int getNumberOfSyntaxElements() {
+    	return childrenOfType(SyntaxElement.class).size();
+    }
+    
+    /**
+     * Indicates that this {@link ExpansionSequence} is essential. That is, this
+     * represents a sequence of more than one syntactical elements.
+     * @return {@code true} iff the number of syntactical child elements > 1
+     */
+    public boolean isEssentialSequence() {
+    	return getNumberOfSyntaxElements() > 1;
     }
 
     Expansion firstNonEmpty() {

--- a/src/java/org/congocc/core/Grammar.java
+++ b/src/java/org/congocc/core/Grammar.java
@@ -283,8 +283,9 @@ public class Grammar extends BaseNode {
     private List<Expansion> getExpansionsForSet(int type) {
         Set<String> usedNames = new LinkedHashSet<>();
         List<Expansion> result = new ArrayList<>();
-        for (Expansion expansion : descendants(Expansion.class)) {
-            if (expansion.getParent() instanceof BNFProduction) continue; // Handle these separately
+        for (Expansion expansion : descendants(Expansion.class)) { // | is this one necessary now that BNFProduction is an Expansion? [jb]
+        														  //  V
+            if ((expansion instanceof BNFProduction) || (expansion.getParent() instanceof BNFProduction)) continue; // Handle these separately
             if (type == 0 || type == 2) {   // follow sets
                 if (expansion instanceof CodeBlock) {
                     continue;
@@ -431,6 +432,17 @@ public class Grammar extends BaseNode {
     public void addCodeInjection(Node n) {
         checkForHooks(n, null);
         codeInjections.add(n);
+    }
+    
+    /**
+     * Adds an injected field to the specified {@link Node} dynamically (post parsing).
+     * @param nodeName is the name of the {@code Node}
+     * @param modifiers is the string of modifiers needed (if any)
+     * @param className is the type of the field
+     * @param fieldName is the name of the field to be injected
+     */
+    public void addFieldInjection(String nodeName, String modifiers, String className, String fieldName) {
+    	CodeInjection.inject(this, nodeName, "{" + modifiers + " " + className + " " + fieldName + ";}");
     }
 
     public boolean isInInclude() {

--- a/src/java/org/congocc/core/NonTerminal.java
+++ b/src/java/org/congocc/core/NonTerminal.java
@@ -1,10 +1,11 @@
 package org.congocc.core;
 
+import org.congocc.core.ExpansionSequence.SyntaxElement;
 import org.congocc.parser.Token.TokenType;
 import org.congocc.parser.tree.*;
 import java.util.Set;
 
-public class NonTerminal extends Expansion {
+public class NonTerminal extends Expansion implements SyntaxElement {
     
     private Name LHS;
     public Name getLHS() {return LHS;}

--- a/src/templates/java/ParserProductions.java.ftl
+++ b/src/templates/java/ParserProductions.java.ftl
@@ -4,6 +4,10 @@
 [#var NODE_USES_PARSER = settings.nodeUsesParser]
 [#var NODE_PREFIX = grammar.nodePrefix]
 [#var currentProduction]
+[#var topLevelExpansion] [#-- A "one-shot" indication that we are processing 
+                              an expansion immediately below the BNF production expansion, 
+                              ignoring an ExpansionSequence that might be there. 
+                          --]
 
 [#macro Productions] 
  //=================================
@@ -51,7 +55,8 @@
        we want the prologue java code block to be able to refer to 
        CURRENT_NODE.
      --]
-     [@BuildCode production.expansion /]
+     [#set topLevelExpansion = false]
+     [@BuildCode production /]
     }   
 [/#macro]
 
@@ -66,14 +71,12 @@
             ${expansion.recoverMethodName}();
          }
          [/#if]
-         [@TreeBuildingAndRecovery expansion]
-           [@BuildExpansionCode expansion/]
-         [/@TreeBuildingAndRecovery]
+         [@BuildExpansionCode expansion/]
      [/@CU.HandleLexicalStateChange]
 [/#macro]
 
 [#macro TreeBuildingAndRecovery expansion]
-   [#var production = expansion.containingProduction, 
+   [#var production = null, 
          treeNodeBehavior,
          buildingTreeNode=false,
          nodeVarName,
@@ -83,10 +86,9 @@
          canRecover = settings.faultTolerant && expansion.tolerantParsing && expansion.simpleName != "Terminal"
    ]
    [#set treeNodeBehavior = resolveTreeNodeBehavior(expansion)]
-   [#if expansion.parent != production] 
-      [#set production = null]
-   [#else]
-      [#set javaCodePrologue = production.javaCode!]
+   [#if expansion == currentProduction]
+      [#set production = currentProduction]
+      [#set javaCodePrologue = production.javaCode!] 
    [/#if]
    [#if treeNodeBehavior??]
       [#if settings.treeBuildingEnabled]
@@ -104,7 +106,7 @@
          [#-- Build the tree node (part 1). --]
          [@buildTreeNode production treeNodeBehavior nodeVarName /]
       [/#if]
-      [#--  The prologue code can refer to CURRENT_NODE at this point. --]
+      [#-- The prologue code can refer to CURRENT_NODE at this point. --]
       ${javaCodePrologue}
       ParseException ${parseExceptionVar} = null;
       int ${callStackSizeVar} = parsingStack.size();
@@ -149,16 +151,17 @@
 [/#macro]
 
 [#function resolveTreeNodeBehavior expansion]
-   [#var treeNodeBehavior = expansion.treeNodeBehavior, production ]
-   [#if expansion.parent.simpleName = "BNFProduction"]
-      [#set production = expansion.parent]
+   [#var treeNodeBehavior = expansion.treeNodeBehavior]
+   [#var isProduction = false]
+   [#if expansion.simpleName = "BNFProduction"]
+      [#set isProduction = true]
    [/#if]
    [#if !treeNodeBehavior??] 
-      [#if production?? && !settings.nodeDefaultVoid]
+      [#if isProduction && !settings.nodeDefaultVoid]
          [#if settings.smartNodeCreation]
-            [#set treeNodeBehavior = {"nodeName" : production.name!"nemo", "condition" : "1", "gtNode" : true, "void" :false, "initialShorthand" : ">"}]
+            [#set treeNodeBehavior = {"nodeName" : expansion.name!"nemo", "condition" : "1", "gtNode" : true, "void" :false, "initialShorthand" : ">"}]
          [#else]
-            [#set treeNodeBehavior = {"nodeName" : production.name!"nemo", "condition" : null, "gtNode" : false, "void" : false}]
+            [#set treeNodeBehavior = {"nodeName" : expansion.name!"nemo", "condition" : null, "gtNode" : false, "void" : false}]
          [/#if]
       [/#if]
    [/#if]
@@ -199,6 +202,14 @@
    }
    ${globals.popNodeVariableName()!}
 [/#macro]
+
+[#function isProductionInstantiatingNode expansion] 
+   [#if expansion.containingProduction.treeNodeBehavior?? && 
+        expansion.containingProduction.treeNodeBehavior.neverInstantiated!false]
+      [#return false/]
+   [/#if]
+   [#return true/]
+[/#function]
 
 [#function nodeVar isProduction]
    [#var nodeVarName]
@@ -246,39 +257,63 @@
 
 
 [#macro BuildExpansionCode expansion]
-    [#var classname=expansion.simpleName]
-    [#var prevLexicalStateVar = CU.newVarName("previousLexicalState")]
-    [#if classname = "ExpansionWithParentheses"]
-       [@BuildExpansionCode expansion.nestedExpansion/]
-    [#elseif classname = "CodeBlock"]
-       ${expansion}
-    [#elseif classname = "UncacheTokens"]
+   [#var classname=expansion.simpleName]
+   [#var prevLexicalStateVar = CU.newVarName("previousLexicalState")]
+   [#-- take care of the non-tree-building classes --]
+   [#if classname = "CodeBlock"]
+      ${expansion}
+   [#elseif classname = "UncacheTokens"]
          uncacheTokens();
-    [#elseif classname = "Failure"]
-       [@BuildCodeFailure expansion/]
-    [#elseif classname = "TokenTypeActivation"]
-       [@BuildCodeTokenTypeActivation expansion/]
-    [#elseif classname = "ExpansionSequence"]
-       [@BuildCodeSequence expansion/]
-    [#elseif classname = "NonTerminal"]
-       [@BuildCodeNonTerminal expansion/]
-    [#elseif classname = "Terminal"]
-       [@BuildCodeTerminal expansion /]
-    [#elseif classname = "TryBlock"]
-       [@BuildCodeTryBlock expansion/]
-    [#elseif classname = "AttemptBlock"]
-       [@BuildCodeAttemptBlock expansion /]
-    [#elseif classname = "ZeroOrOne"]
-       [@BuildCodeZeroOrOne expansion/]
-    [#elseif classname = "ZeroOrMore"]
-       [@BuildCodeZeroOrMore expansion/]
-    [#elseif classname = "OneOrMore"]
-        [@BuildCodeOneOrMore expansion/]
-    [#elseif classname = "ExpansionChoice"]
-        [@BuildCodeChoice expansion/]
-    [#elseif classname = "Assertion"]
-        [@BuildAssertionCode expansion/]
-    [/#if]
+   [#elseif classname = "Failure"]
+      [@BuildCodeFailure expansion/]
+   [#elseif classname = "Assertion"]
+      [@BuildAssertionCode expansion/]
+   [#elseif classname = "TokenTypeActivation"]
+      [@BuildCodeTokenTypeActivation expansion/]
+   [#elseif classname = "TryBlock"]
+      [@BuildCodeTryBlock expansion/]
+   [#elseif classname = "AttemptBlock"]
+      [@BuildCodeAttemptBlock expansion /]
+   [#else]
+      [#-- take care of the tree node (if any) --]
+      [@TreeBuildingAndRecovery expansion]
+         [#if classname = "BNFProduction"]
+            [#-- The tree node having been built, now build the actual top-level expansion --]
+            [#set topLevelExpansion = true]
+            // top-level expansion ${expansion.nestedExpansion.simpleName}
+            [@BuildCode expansion.nestedExpansion/]
+         [#else]
+            [#-- take care of terminal and non-terminal expansions; they cannot contain child expansions --]
+            [#if classname = "NonTerminal"]
+               [@BuildCodeNonTerminal expansion/]
+            [#elseif classname = "Terminal"]
+               [@BuildCodeTerminal expansion /]
+            [#else]
+               [#-- take care of the syntactical expansions (which can contain child expansions) --]
+               [#-- capture the top-level indication in order to restore when bubbling up --]
+               [#var stackedTopLevel = topLevelExpansion]
+               [#if topLevelExpansion && classname != "ExpansionSequence"]
+                  [#-- turn off top-level indication unless an expansion sequence (the tree node has already been determined when this nested template is expanded) --]
+                  [#set topLevelExpansion = false]
+               [/#if]
+               [#if classname = "ZeroOrOne"]
+                  [@BuildCodeZeroOrOne expansion/]
+               [#elseif classname = "ZeroOrMore"]
+                  [@BuildCodeZeroOrMore expansion/]
+               [#elseif classname = "OneOrMore"]
+                  [@BuildCodeOneOrMore expansion/]
+               [#elseif classname = "ExpansionChoice"]
+                  [@BuildCodeChoice expansion/]
+               [#elseif classname = "ExpansionWithParentheses"]
+                  [@BuildExpansionCode expansion.nestedExpansion/]
+               [#elseif classname = "ExpansionSequence"]
+                  [@BuildCodeSequence expansion/] [#-- leave the topLevelExpansion one-shot alone (see above) --]
+               [/#if]
+               [#set topLevelExpansion = stackedTopLevel]
+            [/#if]
+         [/#if]
+      [/@TreeBuildingAndRecovery]
+   [/#if]
 [/#macro]
 
 [#macro BuildCodeFailure fail]
@@ -367,7 +402,6 @@
 [/#macro]
 
 [#macro BuildCodeNonTerminal nonterminal]
-   [#var production = nonterminal.production, LHS]
    pushOntoCallStack("${nonterminal.containingProduction.name}", "${nonterminal.inputSource?j_string}", ${nonterminal.beginLine}, ${nonterminal.beginColumn});
    [#if settings.faultTolerant]
       [#var followSet = nonterminal.followSet]
@@ -386,37 +420,55 @@
       [/#if]
    [/#if]
    try {
-   [#if nonterminal.LHS??]
-      [#set LHS = nonterminal.LHS]
-   [/#if]
-   [#if LHS?? && production.returnType != "void"]
-       ${LHS} = 
-   [/#if]
-      ${nonterminal.name}(${nonterminal.args!});
-   [#if LHS?? && production.returnType = "void"]
-      try {
-         ${LHS} = (${production.nodeName}) peekNode();
-      } catch (ClassCastException cce) {
-         ${LHS} = null;
-      }
-   [/#if]
-   [#if !nonterminal.childName?is_null]
-        if (buildTree) {
-            Node child = peekNode();
-            String name = "${nonterminal.childName}";
-    [#if nonterminal.multipleChildren]
-            ${globals.currentNodeVariableName}.addToNamedChildList(name, child);
-    [#else]
-            ${globals.currentNodeVariableName}.setNamedChild(name, child);
-    [/#if]
-        }
-   [/#if]
+      [@AcceptNonTerminal nonterminal /]
    } 
    finally {
        popCallStack();
    }
 [/#macro]
 
+[#macro AcceptNonTerminal nonterminal]
+   [#var expressedLHS = nonterminal.LHS]
+   [#var impliedLHS = null]
+   [#if nonterminal.production.returnType != "void"]
+      [#if expressedLHS??]
+         ${expressedLHS} = 
+         [#set expressedLHS = null]
+      [/#if]   
+   [/#if]
+   [#-- Accept the non-terminal expansion --]
+   ${nonterminal.name}(${nonterminal.args!});   
+   [#if expressedLHS?? || impliedLHS??]
+      try {
+         [#if expressedLHS??]
+            ${expressedLHS} =
+         [/#if]
+         [#if impliedLHS??]
+            ${impliedLHS} =
+         [/#if]
+         (${nonterminal.production.nodeName}) peekNode(); [#-- There had better be a node here! --]
+      } catch (ClassCastException cce) {
+         [#if expressedLHS??]
+            ${expressedLHS} =
+         [/#if]
+         [#if impliedLHS??]
+            ${impliedLHS} =
+         [/#if] 
+            null;
+      }
+   [/#if]
+   [#if nonterminal.childName??]
+      if (buildTree) {
+         Node child = peekNode();
+         String name = "${nonterminal.childName}";
+      [#if nonterminal.multipleChildren]
+         ${globals.currentNodeVariableName}.addToNamedChildList(name, child);
+      [#else]
+         ${globals.currentNodeVariableName}.setNamedChild(name, child);
+      [/#if]
+      }
+   [/#if] 
+[/#macro]
 
 [#macro BuildCodeZeroOrOne zoo]
     [#if zoo.nestedExpansion.class.simpleName = "ExpansionChoice"]
@@ -485,6 +537,7 @@
    [#list choice.choices as expansion]
       [#if expansion.enteredUnconditionally]
         {
+         // choice for ${globals.currentNodeVariableName} index ${expansion_index}
          ${BuildCode(expansion)}
         }
         [#if expansion_has_next]
@@ -496,6 +549,7 @@
          [#return/]
       [/#if]
       if (${ExpansionCondition(expansion)}) { 
+         // choice for ${globals.currentNodeVariableName} index ${expansion_index}
          ${BuildCode(expansion)}
       }
       [#if expansion_has_next] else [/#if]
@@ -567,7 +621,6 @@
    [/#if]
 [/#macro]
 
-
 [#macro BuildAssertionCode assertion]
    [#var optionalPart = ""]
    [#if assertion.messageExpression??]
@@ -586,7 +639,6 @@
       }
    [/#if]
 [/#macro]
-
 
 [#--
    Macro to build routines that scan up to the start of an expansion


### PR DESCRIPTION
Here is part 1 of changes that are not intended to create any new user-accessible features, but for clarity are separate from part 2.  I revised the method created in ExpansionSequence for detecting > 1 syntactic child to make the intent clearer, I hope.  Part 2 will contain further changes pertaining only to JTB compatible node generation.  The will probably be a part 3 eventually to finish off the feature so that it does not require any syntactic node injections in the user's grammar, which I currently do have.