### PR TITLE
Add check for use of setCachedImage() to MINIMAL_TOKEN setting value

### DIFF
--- a/src/java/org/congocc/app/AppSettings.java
+++ b/src/java/org/congocc/app/AppSettings.java
@@ -489,7 +489,7 @@ public class AppSettings {
         if (getTokenChaining()) return false;
         Boolean b = (Boolean) settings.get("MINIMAL_TOKEN");
         if (b != null) return b;
-        return !checkForMethodName("setImage");
+        return !checkForMethodName("setImage") && !checkForMethodName("setCachedImage");
     }
 
     public boolean getNodeUsesParser() {


### PR DESCRIPTION
So that non-deprecated methods can be used to accomplish this.