### PR TITLE
Make some changes in preparation for incorporating Lua grammar in polyglot tests.

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -27,9 +27,9 @@ jobs:
         java-version: ['8', '11', '17', '19']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'adopt'

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -2,7 +2,7 @@ name: CSharp Generation Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, lua-tests ]
     paths:
         - '**'
         - '!**/*.md'

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -28,9 +28,9 @@ jobs:
         dotnet-version: ['5.0.x', '6.0.x', '7.0.x']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'adopt'
@@ -90,7 +90,7 @@ jobs:
     - name: Cache Jython (POSIX)
       if: ${{ (matrix.os != 'windows-latest') }}
       id: cache-jython-posix
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/bin/jython.jar
         key: ${{ runner.os }}-jython
@@ -101,7 +101,7 @@ jobs:
     - name: Cache Jython (Windows)
       if: ${{ (matrix.os == 'windows-latest') }}
       id: cache-jython-windows
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${env:USERPROFILE}/bin/jython.jar
         key: ${{ runner.os }}-jython
@@ -114,7 +114,7 @@ jobs:
         $destination = "${env:USERPROFILE}/bin/jython.jar"
         Invoke-WebRequest -Uri $source -OutFile $destination
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Run tests

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -35,7 +35,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'adopt'
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     # This next step is needed because we use dotnet 3.1.x to invoke IronPython
@@ -44,7 +44,7 @@ jobs:
     # "dotnet /path/to/ipy.dll")
     - name: Setup dotnet 3.1.x (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '3.1.x'
     - name: Create test directories (POSIX)

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,9 +27,9 @@ jobs:
         java-version: ['8', '11', '17', '19']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'adopt'
@@ -49,7 +49,7 @@ jobs:
     - name: Cache Jython (POSIX)
       if: ${{ (matrix.os != 'windows-latest') }}
       id: cache-jython-posix
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/bin/jython.jar
         key: ${{ runner.os }}-jython
@@ -60,7 +60,7 @@ jobs:
     - name: Cache Jython (Windows)
       if: ${{ (matrix.os == 'windows-latest') }}
       id: cache-jython-windows
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${env:USERPROFILE}/bin/jython.jar
         key: ${{ runner.os }}-jython
@@ -73,7 +73,7 @@ jobs:
         $destination = "${env:USERPROFILE}/bin/jython.jar"
         Invoke-WebRequest -Uri $source -OutFile $destination
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Run tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,7 +2,7 @@ name: Python Generation Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, lua-tests ]
     paths:
         - '**'
         - '!**/*.md'

--- a/csharp_tests.py
+++ b/csharp_tests.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022 Vinay Sajip (vinay_sajip@yahoo.co.uk)
+# Copyright (C) 2022-2023 Vinay Sajip (vinay_sajip@yahoo.co.uk)
 #
 import argparse
 import glob
+import logging
 import os
 import re
 import shutil
@@ -18,6 +19,8 @@ DEBUGGING = 'PY_DEBUG' in os.environ
 
 JYTHON_PATH = None
 VERSION_PATTERN = re.compile(r'\((\d+), (\d+), (\d+).*\)')
+
+logger = logging.getLogger(__name__)
 
 def check_jython(options):
     # First check for Java and Java compiler being available
@@ -98,7 +101,7 @@ def copy_files(srcdir, destdir, patterns):
             # print('%s -> %s' % (p, dp))
 
 def run_command(cmd, **kwargs):
-    # print(' '.join(cmd))
+    logger.debug('Running: %s', ' '.join(cmd))
     return subprocess.run(cmd, **kwargs)
 
 def test_grammar(gdata, options):
@@ -109,10 +112,9 @@ def test_grammar(gdata, options):
     print(s)
     print(line)
 
-    # Create a temp directory and copy files into it.
+    # Copy files into working directory
 
-    workdir = tempfile.mkdtemp(prefix='congocc-csharp-test-')
-    gdata.workdir = workdir
+    workdir = gdata.workdir
     print('Working directory: %s' % workdir)
     if hasattr(gdata, 'srcdir'):
         sd = gdata.srcdir
@@ -295,16 +297,27 @@ def main():
                             cspackage='org.parsers.python', ext='.py',
                             csdir='cs-pythonparser',
                             production='Module'),
+        'lua': Namespace(name='Lua', dir='lua',
+                            grammar='Lua.ccc',
+                            files=['*.ccc', 'testfiles'],
+                            jlexer='org.parsers.lua.LuaLexer',
+                            jparser='org.parsers.lua.LuaParser',
+                            cspackage='org.parsers.lua', ext='.lua',
+                            csdir='cs-luaparser',
+                            production='Root'),
     }
     try:
         langs = options.langs.split(',')
         for lang, gdata in languages.items():
             if options.langs == 'all' or lang in langs:
-                # if lang == 'csharp':
-                    # print('Skipping csharp, because grammar is incomplete')
-                    # continue
+                # For now, skip lua tests unless invoked explicitly
+                # (as they don't work yet)
+                if options.langs == 'all' and lang == 'lua':
+                    continue
+                workdir = tempfile.mkdtemp(prefix='congocc-csharp-test-')
+                workdirs.append(workdir)
+                gdata.workdir = workdir
                 test_grammar(gdata, options)
-                workdirs.append(gdata.workdir)
 
     except Exception as e:
         print('Failed: %s.' % e)
@@ -322,6 +335,12 @@ def main():
 
 if __name__ == '__main__':
     try:
+        fn = os.path.basename(__file__)
+        fn = os.path.splitext(fn)[0]
+        lfn = os.path.expanduser('~/logs/%s.log' % fn)
+        if os.path.isdir(os.path.dirname(lfn)):
+            logging.basicConfig(level=logging.DEBUG, filename=lfn, filemode='w',
+                                format='%(message)s')
         rc = main()
     except KeyboardInterrupt:
         rc = 2

--- a/examples/lua/testfiles/db.lua
+++ b/examples/lua/testfiles/db.lua
@@ -339,7 +339,7 @@ function f(a,b)
   local _, y = debug.getlocal(1, 2)
   assert(x == a and y == b)
   assert(debug.setlocal(2, 3, "pera") == "AA".."AA")
-  assert(debug.setlocal(2, 4, "maÁ„") == "B")
+  assert(debug.setlocal(2, 4, "ma√ß√£") == "B")
   x = debug.getinfo(2)
   assert(x.func == g and x.what == "Lua" and x.name == 'g' and
          x.nups == 2 and string.find(x.source, "^@.*db%.lua$"))
@@ -367,9 +367,9 @@ function g (...)
   local arg = {...}
   do local a,b,c; a=math.sin(40); end
   local feijao
-  local AAAA,B = "xuxu", "mam„o"
+  local AAAA,B = "xuxu", "mam√£o"
   f(AAAA,B)
-  assert(AAAA == "pera" and B == "maÁ„")
+  assert(AAAA == "pera" and B == "ma√ß√£")
   do
      local B = 13
      local x,y = debug.getlocal(1,5)
@@ -402,7 +402,7 @@ end
 function g(a,b) return (a+1) + f() end
 
 assert(g(0,0) == 30)
- 
+
 
 debug.sethook(nil);
 assert(not debug.gethook())
@@ -454,7 +454,7 @@ debug.sethook(function (e)
   dostring("XX = 12")  -- test dostring inside hooks
   -- testing errors inside hooks
   assert(not pcall(load("a='joao'+1")))
-  debug.sethook(function (e, l) 
+  debug.sethook(function (e, l)
     assert(debug.getinfo(2, "l").currentline == l)
     local f,m,c = debug.gethook()
     assert(e == "line")
@@ -517,7 +517,7 @@ do  print("testing inspection of parameters/returned values")
     local t = {}
     for i = ar.ftransfer, ar.ftransfer + ar.ntransfer - 1 do
       local _, v = debug.getlocal(2, i)
-      t[#t + 1] = v 
+      t[#t + 1] = v
     end
     if event == "return" then
       out = t
@@ -571,7 +571,7 @@ assert(t.a == 1 and t.b == 2 and t.c == 3)
 assert(debug.setupvalue(foo1, 1, "xuxu") == "b")
 assert(({debug.getupvalue(foo2, 3)})[2] == "xuxu")
 -- upvalues of C functions are allways "called" "" (the empty string)
-assert(debug.getupvalue(string.gmatch("x", "x"), 1) == "")  
+assert(debug.getupvalue(string.gmatch("x", "x"), 1) == "")
 
 
 -- testing count hooks
@@ -1003,7 +1003,7 @@ end
 do   -- tests for 'source' in binary dumps
   local prog = [[
     return function (x)
-      return function (y) 
+      return function (y)
         return x + y
       end
     end
@@ -1018,7 +1018,7 @@ do   -- tests for 'source' in binary dumps
   local h = g(3)
   assert(h(5) == 8)
   assert(debug.getinfo(f).source == name and   -- all functions have 'source'
-         debug.getinfo(g).source == name and 
+         debug.getinfo(g).source == name and
          debug.getinfo(h).source == name)
   -- again, without debug info
   local c = string.dump(p, true)
@@ -1028,7 +1028,7 @@ do   -- tests for 'source' in binary dumps
   local h = g(30)
   assert(h(50) == 80)
   assert(debug.getinfo(f).source == '=?' and   -- no function has 'source'
-         debug.getinfo(g).source == '=?' and 
+         debug.getinfo(g).source == '=?' and
          debug.getinfo(h).source == '=?')
 end
 

--- a/examples/lua/testfiles/files.lua
+++ b/examples/lua/testfiles/files.lua
@@ -92,8 +92,8 @@ assert(io.output():seek("end") == string.len("alo joao"))
 
 assert(io.output():seek("set") == 0)
 
-assert(io.write('"álo"', "{a}\n", "second line\n", "third line \n"))
-assert(io.write('çfourth_line'))
+assert(io.write('"Ã¡lo"', "{a}\n", "second line\n", "third line \n"))
+assert(io.write('Ã§fourth_line'))
 io.output(io.stdout)
 collectgarbage()  -- file should be closed by GC
 assert(io.input() == io.stdin and rawequal(io.output(), io.stdout))
@@ -300,14 +300,14 @@ do  -- test error returns
 end
 checkerr("invalid format", io.read, "x")
 assert(io.read(0) == "")   -- not eof
-assert(io.read(5, 'l') == '"álo"')
+assert(io.read(5, 'l') == '"Ã¡lo"')
 assert(io.read(0) == "")
 assert(io.read() == "second line")
 local x = io.input():seek()
 assert(io.read() == "third line ")
 assert(io.input():seek("set", x))
 assert(io.read('L') == "third line \n")
-assert(io.read(1) == "ç")
+assert(io.read(1) == "Ã§")
 assert(io.read(string.len"fourth_line") == "fourth_line")
 assert(io.input():seek("cur", -string.len"fourth_line"))
 assert(io.read() == "fourth_line")

--- a/examples/lua/testfiles/pm.lua
+++ b/examples/lua/testfiles/pm.lua
@@ -73,16 +73,16 @@ assert(f('aaa', '^.-$') == 'aaa')
 assert(f('aabaaabaaabaaaba', 'b.*b') == 'baaabaaabaaab')
 assert(f('aabaaabaaabaaaba', 'b.-b') == 'baaab')
 assert(f('alo xo', '.o$') == 'xo')
-assert(f(' \n isto é assim', '%S%S*') == 'isto')
-assert(f(' \n isto é assim', '%S*$') == 'assim')
-assert(f(' \n isto é assim', '[a-z]*$') == 'assim')
+assert(f(' \n isto Ã© assim', '%S%S*') == 'isto')
+assert(f(' \n isto Ã© assim', '%S*$') == 'assim')
+assert(f(' \n isto Ã© assim', '[a-z]*$') == 'assim')
 assert(f('um caracter ? extra', '[^%sa-z]') == '?')
 assert(f('', 'a?') == '')
-assert(f('á', 'á?') == 'á')
-assert(f('ábl', 'á?b?l?') == 'ábl')
-assert(f('  ábl', 'á?b?l?') == '')
+assert(f('Ã¡', 'Ã¡?') == 'Ã¡')
+assert(f('Ã¡bl', 'Ã¡?b?l?') == 'Ã¡bl')
+assert(f('  Ã¡bl', 'Ã¡?b?l?') == '')
 assert(f('aa', '^aa?a?a') == 'aa')
-assert(f(']]]áb', '[^]]') == 'á')
+assert(f(']]]Ã¡b', '[^]]') == 'Ã¡')
 assert(f("0alo alo", "%x*") == "0a")
 assert(f("alo alo", "%C+") == "alo alo")
 print('+')
@@ -136,28 +136,28 @@ assert(string.match("alo xyzK", "(%w+)K") == "xyz")
 assert(string.match("254 K", "(%d*)K") == "")
 assert(string.match("alo ", "(%w*)$") == "")
 assert(not string.match("alo ", "(%w+)$"))
-assert(string.find("(álo)", "%(á") == 1)
-local a, b, c, d, e = string.match("âlo alo", "^(((.).).* (%w*))$")
-assert(a == 'âlo alo' and b == 'âl' and c == 'â' and d == 'alo' and e == nil)
+assert(string.find("(Ã¡lo)", "%(Ã¡") == 1)
+local a, b, c, d, e = string.match("Ã¢lo alo", "^(((.).).* (%w*))$")
+assert(a == 'Ã¢lo alo' and b == 'Ã¢l' and c == 'Ã¢' and d == 'alo' and e == nil)
 a, b, c, d  = string.match('0123456789', '(.+(.?)())')
 assert(a == '0123456789' and b == '' and c == 11 and d == nil)
 print('+')
 
-assert(string.gsub('ülo ülo', 'ü', 'x') == 'xlo xlo')
-assert(string.gsub('alo úlo  ', ' +$', '') == 'alo úlo')  -- trim
+assert(string.gsub('Ã¼lo Ã¼lo', 'Ã¼', 'x') == 'xlo xlo')
+assert(string.gsub('alo Ãºlo  ', ' +$', '') == 'alo Ãºlo')  -- trim
 assert(string.gsub('  alo alo  ', '^%s*(.-)%s*$', '%1') == 'alo alo')  -- double trim
 assert(string.gsub('alo  alo  \n 123\n ', '%s+', ' ') == 'alo alo 123 ')
-t = "abç d"
+t = "abÃ§ d"
 a, b = string.gsub(t, '(.)', '%1@')
 assert('@'..a == string.gsub(t, '', '@') and b == 5)
-a, b = string.gsub('abçd', '(.)', '%0@', 2)
-assert(a == 'a@b@çd' and b == 2)
+a, b = string.gsub('abÃ§d', '(.)', '%0@', 2)
+assert(a == 'a@b@Ã§d' and b == 2)
 assert(string.gsub('alo alo', '()[al]', '%1') == '12o 56o')
 assert(string.gsub("abc=xyz", "(%w*)(%p)(%w+)", "%3%2%1-%0") ==
               "xyz=abc-abc=xyz")
 assert(string.gsub("abc", "%w", "%1%0") == "aabbcc")
 assert(string.gsub("abc", "%w+", "%0%1") == "abcabc")
-assert(string.gsub('áéí', '$', '\0óú') == 'áéí\0óú')
+assert(string.gsub('Ã¡Ã©Ã­', '$', '\0Ã³Ãº') == 'Ã¡Ã©Ã­\0Ã³Ãº')
 assert(string.gsub('', '^', 'r') == 'r')
 assert(string.gsub('', '$', 'r') == 'r')
 print('+')
@@ -187,8 +187,8 @@ do
 end
 
 function f(a,b) return string.gsub(a,'.',b) end
-assert(string.gsub("trocar tudo em |teste|b| é |beleza|al|", "|([^|]*)|([^|]*)|", f) ==
-            "trocar tudo em bbbbb é alalalalalal")
+assert(string.gsub("trocar tudo em |teste|b| Ã© |beleza|al|", "|([^|]*)|([^|]*)|", f) ==
+            "trocar tudo em bbbbb Ã© alalalalalal")
 
 local function dostring (s) return load(s, "")() or "" end
 assert(string.gsub("alo $a='x'$ novamente $return a$",

--- a/examples/lua/testfiles/sort.lua
+++ b/examples/lua/testfiles/sort.lua
@@ -79,7 +79,7 @@ end
 print "testing pack"
 
 a = table.pack()
-assert(a[1] == undef and a.n == 0) 
+assert(a[1] == undef and a.n == 0)
 
 a = table.pack(table)
 assert(a[1] == table and a.n == 1)
@@ -94,8 +94,8 @@ do
   checkerror("table expected", table.move, 1, 2, 3, 4)
 
   local function eqT (a, b)
-    for k, v in pairs(a) do assert(b[k] == v) end 
-    for k, v in pairs(b) do assert(a[k] == v) end 
+    for k, v in pairs(a) do assert(b[k] == v) end
+    for k, v in pairs(b) do assert(a[k] == v) end
   end
 
   local a = table.move({10,20,30}, 1, 3, 2)  -- move forward
@@ -289,7 +289,7 @@ timesort(a, limit,  function(x,y) return nil end, "equal")
 
 for i,v in pairs(a) do assert(v == false) end
 
-A = {"álo", "\0first :-)", "alo", "then this one", "45", "and a new"}
+A = {"Ã¡lo", "\0first :-)", "alo", "then this one", "45", "and a new"}
 table.sort(A)
 check(A)
 

--- a/examples/lua/testfiles/strings.lua
+++ b/examples/lua/testfiles/strings.lua
@@ -91,9 +91,9 @@ assert(string.byte("hi", 2, 1) == nil)
 assert(string.char() == "")
 assert(string.char(0, 255, 0) == "\0\255\0")
 assert(string.char(0, string.byte("\xe4"), 0) == "\0\xe4\0")
-assert(string.char(string.byte("\xe4l\0óu", 1, -1)) == "\xe4l\0óu")
-assert(string.char(string.byte("\xe4l\0óu", 1, 0)) == "")
-assert(string.char(string.byte("\xe4l\0óu", -10, 100)) == "\xe4l\0óu")
+assert(string.char(string.byte("\xe4l\0Ã³u", 1, -1)) == "\xe4l\0Ã³u")
+assert(string.char(string.byte("\xe4l\0Ã³u", 1, 0)) == "")
+assert(string.char(string.byte("\xe4l\0Ã³u", -10, 100)) == "\xe4l\0Ã³u")
 
 checkerror("out of range", string.char, 256)
 checkerror("out of range", string.char, -1)
@@ -103,7 +103,7 @@ checkerror("out of range", string.char, math.mininteger)
 assert(string.upper("ab\0c") == "AB\0C")
 assert(string.lower("\0ABCc%$") == "\0abcc%$")
 assert(string.rep('teste', 0) == '')
-assert(string.rep('tés\00tê', 2) == 'tés\0têtés\000tê')
+assert(string.rep('tÃ©s\00tÃª', 2) == 'tÃ©s\0tÃªtÃ©s\000tÃª')
 assert(string.rep('', 10) == '')
 
 if string.packsize("i") == 4 then
@@ -192,8 +192,8 @@ do  -- tests for '%p' format
   end
 end
 
-x = '"ílo"\n\\'
-assert(string.format('%q%s', x, x) == '"\\"ílo\\"\\\n\\\\""ílo"\n\\')
+x = '"Ã­lo"\n\\'
+assert(string.format('%q%s', x, x) == '"\\"Ã­lo\\"\\\n\\\\""Ã­lo"\n\\')
 assert(string.format('%q', "\0") == [["\0"]])
 assert(load(string.format('return %q', x))() == x)
 x = "\0\1\0023\5\0009"
@@ -328,7 +328,7 @@ do print("testing 'format %a %A'")
     assert(string.find(string.format("%a", 0/0), "^%-?nan"))
     assert(string.find(string.format("%a", -0.0), "^%-0x0"))
   end
-  
+
   if not pcall(string.format, "%.3a", 0) then
     (Message or print)("\n >>> modifiers for format '%a' not available <<<\n")
   else
@@ -425,14 +425,14 @@ if not _port then
   end
 
   if trylocale("collate")  then
-    assert("alo" < "álo" and "álo" < "amo")
+    assert("alo" < "Ã¡lo" and "Ã¡lo" < "amo")
   end
 
   if trylocale("ctype") then
-    assert(string.gsub("áéíóú", "%a", "x") == "xxxxx")
-    assert(string.gsub("áÁéÉ", "%l", "x") == "xÁxÉ")
-    assert(string.gsub("áÁéÉ", "%u", "x") == "áxéx")
-    assert(string.upper"áÁé{xuxu}ção" == "ÁÁÉ{XUXU}ÇÃO")
+    assert(string.gsub("Ã¡Ã©Ã­Ã³Ãº", "%a", "x") == "xxxxx")
+    assert(string.gsub("Ã¡ÃÃ©Ã‰", "%l", "x") == "xÃxÃ‰")
+    assert(string.gsub("Ã¡ÃÃ©Ã‰", "%u", "x") == "Ã¡xÃ©x")
+    assert(string.upper"Ã¡ÃÃ©{xuxu}Ã§Ã£o" == "ÃÃÃ‰{XUXU}Ã‡ÃƒO")
   end
 
   os.setlocale("C")

--- a/ptest.py
+++ b/ptest.py
@@ -141,9 +141,12 @@ else:
 
 
 def main():
-    fn = os.path.expanduser('~/logs/ptest.log')
-    logging.basicConfig(level=logging.DEBUG, filename=fn, filemode='w',
-                        format='%(message)s')
+    fn = os.path.basename(__file__)
+    fn = os.path.splitext(fn)[0]
+    lfn = os.path.expanduser('~/logs/%s.log' % fn)
+    if os.path.isdir(os.path.dirname(lfn)):
+        logging.basicConfig(level=logging.DEBUG, filename=lfn, filemode='w',
+                            format='%(message)s')
     adhf = argparse.ArgumentDefaultsHelpFormatter
     ap = argparse.ArgumentParser(formatter_class=adhf)
     aa = ap.add_argument
@@ -293,9 +296,9 @@ def main():
                             done = t.Type == TokenType.EOF
                         else:
                             done = t.type == TokenType.EOF
-            except Exception as e:
+            except Exception:
                 import traceback
-                traceback.print_exc(e)
+                traceback.print_exc()
             finally:
                 try:
                     if f:

--- a/src/java/org/congocc/codegen/python/PythonTranslator.java
+++ b/src/java/org/congocc/codegen/python/PythonTranslator.java
@@ -369,7 +369,13 @@ public class PythonTranslator extends Translator {
                 renderReceiver(receiver, result);
                 result.append('.');
             }
-            String ident = translateIdentifier(methodName, TranslationContext.METHOD);
+            String ident;
+            if ((nargs == 1) && (methodName.equals("startsWith") || methodName.equals("endsWith"))) {
+                ident = methodName.toLowerCase();
+            }
+            else {
+                ident = translateIdentifier(methodName, TranslationContext.METHOD);
+            }
             result.append(ident);
             translateArguments(expr.getArguments(), true, result);
         }


### PR DESCRIPTION
Changes fall into these categories:

* Change workflow actions to avoid warnings.
* Added logging and `'lua'` fixture to test scripts, but arranged to only run tests with the Lua grammar if explicitly requested (as they're not passing yet).
* Change location of working directory computation in test scripts.
* Change Lua `testfiles/` scripts which were `iso-8859-1` encoded to be encoded in `utf-8` (no other changes, other than trailing whitespace removal).