### PR TITLE
Implement reapers for parsers generated in Python and C#.

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: ['8', '11', '17', '21']
+        java-version: ['17', '21']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: ['17', '21']
+        java-version: ['8', '11', '17', '21']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -27,6 +27,9 @@ jobs:
         os: [ubuntu-22.04, macos-latest, windows-latest]
         java-version: ['17', '21']
         dotnet-version: ['5.0.x', '6.0.x', '7.0.x', '8.0.x']
+        exclude:
+            - os: windows-latest
+              java-version: '17'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        java-version: ['17', '21']
+        java-version: ['8', '11', '17', '21']
         dotnet-version: ['5.0.x', '6.0.x', '7.0.x', '8.0.x']
 
     steps:

--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        java-version: ['8', '11', '17', '21']
+        java-version: ['17', '21']
         dotnet-version: ['5.0.x', '6.0.x', '7.0.x', '8.0.x']
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: ['8', '11', '17', '21']
+        java-version: ['17', '21']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: ['17', '21']
+        java-version: ['8', '11', '17', '21']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,6 +26,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         java-version: ['17', '21']
+        exclude:
+            - os: windows-latest
+              java-version: '17'
 
     steps:
     - uses: actions/checkout@v4

--- a/src/grammars/CongoCC.ccc
+++ b/src/grammars/CongoCC.ccc
@@ -134,15 +134,13 @@ INJECT PARSER_CLASS :
         return parser.CompilationUnit();
     }
 
-    static public Module parsePythonFile(String inputSource, CharSequence content, boolean useAltIndentDedent) {
+    static public Module parsePythonFile(String inputSource, CharSequence content) {
         PythonParser parser = new PythonParser(inputSource, content);
-//        parser.setUseAltIndentDedent(useAltIndentDedent);
         return parser.Module();
     }
 
-    static public Module parsePythonFile(Path path, boolean useAltIndentDedent) throws IOException {
+    static public Module parsePythonFile(Path path) throws IOException {
         PythonParser parser = new PythonParser(path);
-//        parser.setUseAltIndentDedent(useAltIndentDedent);
         return parser.Module();
     }
 

--- a/src/java/org/congocc/codegen/csharp/Reaper.java
+++ b/src/java/org/congocc/codegen/csharp/Reaper.java
@@ -27,16 +27,16 @@ public class Reaper {
         if ("true".equals(System.getenv("CONGOCC_CSHARP_REAPER_OFF"))) {
             return;
         }
-        List<ClassDeclaration> classes = cu.descendantsOfType(ClassDeclaration.class);
-        Optional<ClassDeclaration> opc = classes.stream().filter(Reaper::isParserClass).findFirst();
 
-        if (!opc.isPresent()) {
+        List<ClassDeclaration> classes = cu.descendantsOfType(ClassDeclaration.class);
+        ClassDeclaration pc = cu.firstDescendantOfType(ClassDeclaration.class, Reaper::isParserClass);
+        if (pc == null) {
             return;
         }
-        ClassDeclaration pc = opc.get();
-        List<FieldDeclaration> fieldDecls = pc.childrenOfType(FieldDeclaration.class);
 
+        List<FieldDeclaration> fieldDecls = pc.childrenOfType(FieldDeclaration.class);
         Map<String, FieldDeclaration> parserSets = new HashMap<>();
+
         for (FieldDeclaration fd : fieldDecls) {
             List<VariableDeclarator> varDecls = fd.childrenOfType(VariableDeclarator.class);
 

--- a/src/java/org/congocc/codegen/csharp/Reaper.java
+++ b/src/java/org/congocc/codegen/csharp/Reaper.java
@@ -1,0 +1,144 @@
+package org.congocc.codegen.csharp;
+
+import java.util.*;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.congocc.parser.Node;
+import org.congocc.parser.csharp.ast.*;
+
+public class Reaper {
+    private final CompilationUnit cu;
+    private static final Pattern parserSetPattern = Pattern.compile("(first|follow)_set", Pattern.CASE_INSENSITIVE);
+    private static final Pattern methodPattern = Pattern.compile("Parse|(backscan|scan|check|assert|recover)Σ");
+
+    public Reaper(CompilationUnit cu) {
+        this.cu = cu;
+    }
+
+    private static boolean isParserClass(ClassDeclaration cd) {
+        Identifier ident = cd.firstChildOfType(Identifier.class);
+
+        return (ident != null) && ident.toString().equals("Parser");
+    }
+
+    public void reap() {
+        if ("true".equals(System.getenv("CONGOCC_CSHARP_REAPER_OFF"))) {
+            return;
+        }
+        List<ClassDeclaration> classes = cu.descendantsOfType(ClassDeclaration.class);
+        Optional<ClassDeclaration> opc = classes.stream().filter(Reaper::isParserClass).findFirst();
+
+        if (!opc.isPresent()) {
+            return;
+        }
+        ClassDeclaration pc = opc.get();
+        List<FieldDeclaration> fieldDecls = pc.childrenOfType(FieldDeclaration.class);
+
+        Map<String, FieldDeclaration> parserSets = new HashMap<>();
+        for (FieldDeclaration fd : fieldDecls) {
+            List<VariableDeclarator> varDecls = fd.childrenOfType(VariableDeclarator.class);
+
+            for (VariableDeclarator vd : varDecls) {
+                String name = vd.firstChildOfType(Identifier.class).toString();
+
+                if (parserSetPattern.matcher(name).find()) {
+                    parserSets.put(name, fd);
+                }
+            }
+        }
+
+        List<MethodDeclaration> methods = pc.childrenOfType(MethodDeclaration.class);
+        Map<String, MethodDeclaration> wantedMethods = new HashMap<>();
+        Map<String, MethodDeclaration> otherMethods = new HashMap<>();
+
+        for (MethodDeclaration m : methods) {
+            List<Identifier> idents = m.childrenOfType(Identifier.class);
+            String name = idents.get(idents.size() - 1).toString();
+
+            if (methodPattern.matcher(name).find()) {
+                if (name.startsWith("Parse")) {
+                    wantedMethods.put(name, m);
+                }
+                else {
+                    otherMethods.put(name, m);
+                }
+            }
+        }
+/*
+        We now do multiple passes to resolve dependencies. In each pass, we loop through the methods
+        to be inspected (the wanted_methods, initially) and look for names of parser sets or other
+        methods. If a parser set name is found, remove it from the parser_sets as is referenced in
+        a method we're going to keep. If a method name is found, add it to a "to_inspect" map which
+        represents methods to be kept and which will be examined in later passes. When there are no
+        more to inspect, the passes end. The methods to be examined in the next pass will be
+        transferred from other_methods to an inspect_next mapping.
+*/
+        Map<String, MethodDeclaration> toInspect = wantedMethods;
+        while (!toInspect.isEmpty()) {
+            Map<String, MethodDeclaration> inspectNext = new HashMap<>();
+
+            for (MethodDeclaration method : toInspect.values()) {
+                Block block = method.firstChildOfType(Block.class);
+
+                Set<String> names = new HashSet<>();
+                for (Identifier ident : block.descendantsOfType(Identifier.class)) {
+                    names.add(ident.toString());
+                }
+                for (String n : names) {
+                    if (parserSets.containsKey(n)) {
+                        parserSets.remove(n);
+                    }
+                    else if (otherMethods.containsKey(n)) {
+                        inspectNext.put(n, otherMethods.get(n));
+                        otherMethods.remove(n);
+                    }
+                }
+            }
+            wantedMethods.putAll(inspectNext);
+            toInspect = inspectNext;
+        }
+        // What's left in parserSets and otherMethods are now apparently never used
+        for (FieldDeclaration fd : parserSets.values()) {
+            fd.getParent().remove(fd);
+        }
+        for (MethodDeclaration meth : otherMethods.values()) {
+            meth.getParent().remove(meth);
+        }
+/*
+        Now go through the wanted methods looking for unused scanToEnd variables, and remove their
+        declarations. We just look for the identifier in later statements in the method to determine
+        usage - pretty simplistic.
+*/
+        for (MethodDeclaration meth : wantedMethods.values()) {
+            Block block = meth.firstChildOfType(Block.class);
+            List<Node> statements = block.children();
+            Node found = null;
+
+            for (Node statement : statements) {
+                if (found == null) {
+                    if (statement.toString().equals("var scanToEnd = false;")) {
+                        found = statement;
+                        continue;
+                    }
+                }
+                else {
+                    List<Identifier> idents = statement.descendantsOfType(Identifier.class);
+                    for (Identifier ident: idents) {
+                        if (ident.toString().equals("scanToEnd")) {
+                            found = null;  // pretend we never found it, so it can't be removed
+                            break;
+                        }
+                    }
+                    if (found == null) {    // was reset above, no need to look further
+                        break;
+                    }
+                }
+            }
+            if (found != null) {
+                found.getParent().remove(found);
+            }
+        }
+    }
+}

--- a/src/java/org/congocc/codegen/python/Reaper.java
+++ b/src/java/org/congocc/codegen/python/Reaper.java
@@ -32,14 +32,13 @@ public class Reaper {
         if ("true".equals(System.getenv("CONGOCC_PYTHON_REAPER_OFF"))) {
             return;
         }
-        List<ClassDefinition> classes = module.descendantsOfType(ClassDefinition.class);
-        Optional<ClassDefinition> pc = classes.stream().filter(Reaper::isParserClass).findFirst();
 
-        if (!pc.isPresent()) {
+        ClassDefinition pc = module.firstDescendantOfType(ClassDefinition.class, Reaper::isParserClass);
+        if (pc == null) {
             return;
         }
 
-        Node block = pc.get().getLastChild();
+        Node block = pc.getLastChild();
         assert block instanceof Block;
         List<Statement> statements = block.childrenOfType(Statement.class);
         List<Statement> assignments = statements.stream().filter(Reaper::isAssignment).collect(Collectors.toList());

--- a/src/java/org/congocc/codegen/python/Reaper.java
+++ b/src/java/org/congocc/codegen/python/Reaper.java
@@ -1,0 +1,114 @@
+package org.congocc.codegen.python;
+
+import java.util.*;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.congocc.parser.Node;
+import org.congocc.parser.python.ast.*;
+
+public class Reaper {
+    private final Module module;
+    private static final Pattern parserSetPattern = Pattern.compile("(first|follow)_set", Pattern.CASE_INSENSITIVE);
+    private static final Pattern methodPattern = Pattern.compile("parse_|(backscan|scan|check|assert|recover)Σ");
+
+    public Reaper(Module module) {
+        this.module = module;
+    }
+
+    private static boolean isAssignment(Statement stmt) {
+        return stmt.getFirstChild() instanceof Assignment;
+    }
+
+    private static boolean isParserClass(ClassDefinition cd) {
+        Name name = cd.firstChildOfType(Name.class);
+
+        return (name != null) && name.toString().equals("Parser");
+    }
+
+    public void reap() {
+        if ("true".equals(System.getenv("CONGOCC_PYTHON_REAPER_OFF"))) {
+            return;
+        }
+        List<ClassDefinition> classes = module.descendantsOfType(ClassDefinition.class);
+        Optional<ClassDefinition> pc = classes.stream().filter(Reaper::isParserClass).findFirst();
+
+        if (!pc.isPresent()) {
+            return;
+        }
+
+        Node block = pc.get().getLastChild();
+        assert block instanceof Block;
+        List<Statement> statements = block.childrenOfType(Statement.class);
+        List<Statement> assignments = statements.stream().filter(Reaper::isAssignment).collect(Collectors.toList());
+
+        Map<String, Statement> parserSets = new HashMap<>();
+        for (Statement a : assignments) {
+            String name = a.getFirstChild().getFirstChild().toString();
+
+            if (parserSetPattern.matcher(name).find()) {
+                parserSets.put(name, a);
+            }
+        }
+
+        Map<String, FunctionDefinition> wantedMethods = new HashMap<>();
+        Map<String, FunctionDefinition> otherMethods = new HashMap<>();
+        List<FunctionDefinition> funcs = block.childrenOfType(FunctionDefinition.class);
+        for (FunctionDefinition f : funcs) {
+            String name = f.firstChildOfType(Name.class).toString();
+
+            if (methodPattern.matcher(name).find()) {
+                if (name.startsWith("parse_")) {
+                    wantedMethods.put(name, f);
+                }
+                else {
+                    otherMethods.put(name, f);
+                }
+            }
+        }
+/*
+        We now do multiple passes to resolve dependencies. In each pass, we loop through the methods
+        to be inspected (the wanted_methods, initially) and look for names of parser sets or other
+        methods. If a parser set name is found, remove it from the parser_sets as is referenced in
+        a method we're going to keep. If a method name is found, add it to a "to_inspect" map which
+        represents methods to be kept and which will be examined in later passes. When there are no
+        more to inspect, the passes end. The methods to be examined in the next pass will be
+        transferred from other_methods to an inspect_next mapping.
+*/
+        Map<String, FunctionDefinition> toInspect = wantedMethods;
+        while (!toInspect.isEmpty()) {
+            Map<String, FunctionDefinition> inspectNext = new HashMap<>();
+
+            for (FunctionDefinition method : toInspect.values()) {
+                block = method.getLastChild();
+                assert block instanceof Block;
+
+                Set<String> dotNames = new HashSet<>();
+                for (DotName dn : block.descendantsOfType(DotName.class)) {
+                    Node last = dn.getLastChild();
+                    dotNames.add(last.toString());
+                }
+                for (String dn : dotNames) {
+                    if (parserSets.containsKey(dn)) {
+                        parserSets.remove(dn);
+                    }
+                    else if (otherMethods.containsKey(dn)) {
+                        inspectNext.put(dn, otherMethods.get(dn));
+                        otherMethods.remove(dn);
+                    }
+                }
+            }
+            wantedMethods.putAll(inspectNext);
+            toInspect = inspectNext;
+        }
+        // What's left in parserSets and otherMethods are now apparently never used
+        for (Statement stmt : parserSets.values()) {
+            stmt.getParent().remove(stmt);
+        }
+        for (FunctionDefinition fd : otherMethods.values()) {
+            fd.getParent().remove(fd);
+        }
+    }
+}


### PR DESCRIPTION
These don't use the visitor pattern, but instead focus only on the Parser class, where almost all of the benefits are to be had. Unreferenced methods other than those in the parser API and unused first and follow sets are removed.