### PR TITLE
Fix arithmetic/freemarker documentation and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/*
 /examples/freemarker/felparser/*
 /examples/freemarker/cs-felparser/*
 /examples/freemarker/Java*IdentifierDef.ccc
+/examples/arithmetic/ex1/*
+/examples/arithmetic/ex2/*
 /examples/legacy/test.tmp/*
 /examples/java/org/*
 /examples/java/javaparser/*

--- a/examples/arithmetic/README.md
+++ b/examples/arithmetic/README.md
@@ -6,9 +6,9 @@ The `Arithmetic2.ccc` uses (via INCLUDE) the grammar defined in `Arithmetic1.ccc
 
 To build the examples:
 
-     java -jar <path_to_jar>/congocc-full.jar Arithmetic1.ccc
+     java -jar <path_to_jar>/congocc.jar Arithmetic1.ccc
      javac ex1/*.java
-     java -jar<path_to_jar>/congocc-full.jar Arithmetic2.ccc
+     java -jar<path_to_jar>/congocc.jar Arithmetic2.ccc
      javac ex2/*.java
 
 To test it:

--- a/examples/freemarker/README.md
+++ b/examples/freemarker/README.md
@@ -9,7 +9,7 @@ full FTL grammar simply INCLUDE's the FEL grammar.
 
 To test the FEL grammar, simply cd into the FEL directory, and execute:
 
-java -jar congocc-full.jar FEL.ccc
+java -jar congocc.jar FEL.ccc
 
 at the command prompt. After that, do:
 


### PR DESCRIPTION
The README files in the examples/arithmetic and examples/freemarker appear to be referring to an older version of the congocc jar file. This commit just fixes those READMEs files and also adds the ex1/ex2 arithmetic output directories to gitignore.