### PR TITLE
Make the Arithmetic example more newbie-friendly

### DIFF
--- a/examples/arithmetic/Arithmetic1.ccc
+++ b/examples/arithmetic/Arithmetic1.ccc
@@ -48,14 +48,30 @@ INJECT PARSER_CLASS :
     import java.util.Scanner;
 {
     static public void main(String[] args) throws ParseException {
-       Scanner scanner = new Scanner(System.in);
-       String input = scanner.nextLine();
+       String input = "";
+       if (args.length > 0)
+       {
+         System.out.println("Parsing arithmetic expression from the command line");
+         input = String.join("\n", args);
+       } else {
+         System.out.println("Enter an arithmetic expression:");
+         Scanner scanner = new Scanner(System.in);
+         input = scanner.nextLine();
+       }
+
        PARSER_CLASS parser = new PARSER_CLASS(input);
        parser.Root();
        Node root = parser.rootNode();
        System.out.println("Dumping the AST...");
        root.dump();
-       System.out.println("The result is: " + root.evaluate());
+
+       try {
+         System.out.println("The result is: " + root.evaluate());
+       }
+       catch (UnsupportedOperationException e) {
+         System.err.println("Failed to evaluate expression. Are you running ex1.Calc? If so, you probably want to run ex2.Calc.");
+         System.exit(-1);
+       }
     }
 }
 

--- a/examples/arithmetic/README.md
+++ b/examples/arithmetic/README.md
@@ -4,17 +4,10 @@ The `Arithmetic1.ccc` grammar just defines a very simple grammar.
 
 The `Arithmetic2.ccc` uses (via INCLUDE) the grammar defined in `Arithmetic1.ccc` and defines via (INJECT) the routines to evaluate the various nodes in the generated tree.
 
-To build the examples:
+To build and run a simple test:
 
-     java -jar <path_to_jar>/congocc.jar Arithmetic1.ccc
-     javac ex1/*.java
-     java -jar<path_to_jar>/congocc.jar Arithmetic2.ccc
-     javac ex2/*.java
+     ant test
 
 To test it:
-
-    java ex1.Calc
-
-and:
 
     java ex2.Calc

--- a/examples/arithmetic/build.xml
+++ b/examples/arithmetic/build.xml
@@ -1,0 +1,43 @@
+<project name="CongoCC Arithmetic example" default="compile">
+  <target name="clean">
+    <delete dir="ex1" />
+    <delete dir="ex2" />
+  </target>
+
+  <target name="init">
+    <uptodate property="javaparser.uptodate" srcfile="Arithmetic1.ccc" targetfile="ex1/Calc.java" />
+    <uptodate property="javaparser.uptodate" srcfile="Arithmetic2.ccc" targetfile="ex2/Calc.java" />
+  </target>
+
+  <target name="parser-gen" depends="init" unless="javaparser.uptodate">
+    <java jar="../../congocc.jar" failonerror="true" fork="true">
+      <assertions>
+        <enable />
+      </assertions>
+      <arg value="-q" />
+      <arg value="${basedir}/Arithmetic1.ccc" />
+    </java>
+    <java jar="../../congocc.jar" failonerror="true" fork="true">
+      <assertions>
+        <enable />
+      </assertions>
+      <arg value="-q" />
+      <arg value="${basedir}/Arithmetic2.ccc" />
+    </java>
+  </target>
+
+  <target name="compile" depends="init, parser-gen">
+    <javac srcdir="${basedir}/ex1" failonerror="true" release="8" excludes="testfiles/**" classpath="." debug="on" optimize="off" includeantruntime="no" fork="true" />
+    <javac srcdir="${basedir}/ex2" failonerror="true" release="8" excludes="testfiles/**" classpath="." debug="on" optimize="off" includeantruntime="no" fork="true" />
+  </target>
+
+  <target name="test" depends="compile">
+    <java fork="true" classpath="." classname="ex2.Calc">
+      <assertions>
+        <enable />
+      </assertions>
+      <arg value="1+1" />
+    </java>
+  </target>
+
+</project>


### PR DESCRIPTION
This commit adds a build.xml so that it is easy to build by ant and updates the example so that it can parse arithmetic expressions passed in as an argument. The overall intention is to bring this example to a state where it can be used in a CongoCC tutorial.