### PR TITLE
Rebuild Arithmetic if any of the .ccc files change

### DIFF
--- a/examples/arithmetic/build.xml
+++ b/examples/arithmetic/build.xml
@@ -5,11 +5,12 @@
   </target>
 
   <target name="init">
-    <uptodate property="javaparser.uptodate" srcfile="Arithmetic1.ccc" targetfile="ex1/Calc.java" />
-    <uptodate property="javaparser.uptodate" srcfile="Arithmetic2.ccc" targetfile="ex2/Calc.java" />
+    <uptodate property="ccc.uptodate" targetfile="${basedir}/ex2/Calc.java">
+      <srcfiles dir="${basedir}" includes="*.ccc" />
+    </uptodate>
   </target>
 
-  <target name="parser-gen" depends="init" unless="javaparser.uptodate">
+  <target name="parser-gen" depends="init" unless="ccc.uptodate">
     <java jar="../../congocc.jar" failonerror="true" fork="true">
       <assertions>
         <enable />
@@ -26,7 +27,7 @@
     </java>
   </target>
 
-  <target name="compile" depends="init, parser-gen">
+  <target name="compile" depends="parser-gen">
     <javac srcdir="${basedir}/ex1" failonerror="true" release="8" excludes="testfiles/**" classpath="." debug="on" optimize="off" includeantruntime="no" fork="true" />
     <javac srcdir="${basedir}/ex2" failonerror="true" release="8" excludes="testfiles/**" classpath="." debug="on" optimize="off" includeantruntime="no" fork="true" />
   </target>


### PR DESCRIPTION
This commit fixes the build.xml so that if either Arithmetic1.ccc or Arithmetic2.ccc is modified independently, everything is recompiled again properly. As it stands now, changes to Arithmetic1.ccc alone will not retrigger a compile.