### PR TITLE
Modify behaviour of firstDescendantOfType to walk all the descendants until a match is found

### DIFF
--- a/src/templates/csharp/Tokens.cs.ctl
+++ b/src/templates/csharp/Tokens.cs.ctl
@@ -227,11 +227,9 @@ namespace ${csPackage} {
                         return tok;
                     }
                 }
-                else {
-                    tok = child.FirstDescendantOfType(tt);
-                    if (tok != null) {
-                        return tok;
-                    }
+                tok = child.FirstDescendantOfType(tt);
+                if (tok != null) {
+                    return tok;
                 }
             }
             return null;

--- a/src/templates/java/Node.java.ctl
+++ b/src/templates/java/Node.java.ctl
@@ -397,10 +397,9 @@ public interface Node extends List<Node> {
              Node child = get(i);
              if (child.getType() == type) {
                 if (pred == null || pred.test(child)) return child;
-             } else {
-                 Node tok = child.firstDescendantOfType(type, pred);
-                 if (tok != null) return tok;
              }
+             Node tok = child.firstDescendantOfType(type, pred);
+             if (tok != null) return tok;
          }
          return null;
     }
@@ -440,10 +439,8 @@ public interface Node extends List<Node> {
                 T t = clazz.cast(child);
                 if (pred == null || pred.test(t)) return t;
              }
-             else {
-                 T descendant = child.firstDescendantOfType(clazz, pred);
-                 if (descendant != null) return descendant;
-             }
+             T descendant = child.firstDescendantOfType(clazz, pred);
+             if (descendant != null) return descendant;
          }
          return null;
     }

--- a/src/templates/python/tokens.py.ctl
+++ b/src/templates/python/tokens.py.ctl
@@ -239,10 +239,9 @@ class ${settings.baseNodeClassName}:
             if isinstance(child, Token):
                 if child.type == type:
                     return child
-            else:
-                child = child.first_descendant_of_type(type)
-                if child:
-                    return child
+            child = child.first_descendant_of_type(type)
+            if child:
+                return child
 
     def descendants(self, cls=None, predicate=None):
         if cls is None:


### PR DESCRIPTION
With the current implementation, if a child matches the class but then it does not match the predicate, then its descendants are never checked.

If such behaviour was indeed the expected one then this PR should be discarded, thanks.