### PR TITLE
Add ASSERT/ENSURE lookBehind to Python and C# templates

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -218,6 +218,17 @@
     <ant dir="examples/java" target="test-java" />
   </target>
 
+  <!-- Cardinality oracles (Java): sandbox/cardinality (CardTests.ccc) and examples/cics.
+       When Python/C# cardinality codegen lands, extend these dirs with -lang python/csharp checks. -->
+  <target name="test-cardinality-oracles-java" depends="jar">
+    <echo>Cardinality oracle: sandbox/cardinality</echo>
+    <ant dir="sandbox/cardinality" target="clean" />
+    <ant dir="sandbox/cardinality" target="test" />
+    <echo>Cardinality oracle: examples/cics</echo>
+    <ant dir="examples/cics" target="clean" />
+    <ant dir="examples/cics" target="test" />
+  </target>
+
   <target name="test-rust" depends="jar,-rust-guard" if="rust.on">
     <echo>Testing Rust parser generation</echo>
     <ant dir="examples/json" target="test-rust" />

--- a/src/templates/csharp/CommonUtils.inc.ctl
+++ b/src/templates/csharp/CommonUtils.inc.ctl
@@ -131,3 +131,7 @@ finally {
 #-- # DBG < HandleLexicalStateChange ${expansion.simpleName}
 #endmacro
 
+#-- Jagged int[][] initializer for RepetitionCardinality (mirrors Java CommonUtils.BuildCardinalities). --
+#macro BuildCardinalities assertions
+new int[][] { [#list assertions as range]new int[] { ${range[0]}, ${range[1]} }[#if range_has_next], [/#if][/#list] }
+#endmacro

--- a/src/templates/csharp/LookaheadRoutines.inc.ctl
+++ b/src/templates/csharp/LookaheadRoutines.inc.ctl
@@ -505,7 +505,12 @@ if (!ScanToken(${expansion.firstSetVarName})) {
 
 #macro ScanCodeAssertion assertion
 #-- # DBG > ScanCodeAssertion
-#if assertion.assertionExpression??
+#if assertion.lookBehind??
+if ([#if !assertion.lookBehind.negated]![/#if]${assertion.lookBehind.routineName}()) {
+    _hitFailure = true;
+    return false;
+}
+#elseif assertion.assertionExpression??
 if (!(${globals::translateExpression(assertion.assertionExpression)})) {
     _hitFailure = true;
     return false;

--- a/src/templates/csharp/Parser.cs.ctl
+++ b/src/templates/csharp/Parser.cs.ctl
@@ -190,6 +190,126 @@ ${globals::translateParserImports()}
 
         private const uint UNLIMITED = (1U << 31) - 1;
 
+#if grammar.usingCardinality
+        private sealed class CardinalityState {
+            private readonly int[] _cardinalities;
+            public bool IsProvisional { get; }
+
+            public CardinalityState(int[] cardinalities, bool isProvisional) {
+                _cardinalities = (int[])cardinalities.Clone();
+                IsProvisional = isProvisional;
+            }
+
+            public int[] Cardinalities() {
+                return (int[])_cardinalities.Clone();
+            }
+        }
+
+        private sealed class RepetitionCardinality {
+            private readonly int[][] _choiceCardinalities;
+            private readonly Stack<CardinalityState> _cardinalitiesStack = new Stack<CardinalityState>();
+            private readonly int[] _cardinalities;
+
+            public RepetitionCardinality(int[][] choiceCardinalities) {
+                _choiceCardinalities = choiceCardinalities;
+                int n = choiceCardinalities.Length;
+                _cardinalitiesStack.Push(new CardinalityState(new int[n], false));
+                _cardinalities = new int[n];
+            }
+
+            public bool Choose(int choiceNo, bool isLookahead) {
+                if (isLookahead) {
+                    CardinalityState currentState = _cardinalitiesStack.Peek();
+                    CardinalityState priorState = currentState;
+                    if (!currentState.IsProvisional) {
+                        Push(true);
+                    }
+                    else {
+                        CardinalityState provisionalTop = _cardinalitiesStack.Pop();
+                        priorState = _cardinalitiesStack.Peek();
+                        _cardinalitiesStack.Push(provisionalTop);
+                    }
+                    currentState = _cardinalitiesStack.Peek();
+                    int[] currentCardinalities = currentState.Cardinalities();
+                    int[] priorCardinalities = priorState.Cardinalities();
+                    if (currentCardinalities[choiceNo] == priorCardinalities[choiceNo]) {
+                        if (currentCardinalities[choiceNo] < _choiceCardinalities[choiceNo][1]) {
+                            ++currentCardinalities[choiceNo];
+                            _cardinalitiesStack.Pop();
+                            _cardinalitiesStack.Push(new CardinalityState(currentCardinalities, true));
+                            return true;
+                        }
+                    }
+                    else {
+                        return true;
+                    }
+                }
+                else {
+                    if (_cardinalities[choiceNo] < _choiceCardinalities[choiceNo][1]) {
+                        ++_cardinalities[choiceNo];
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public void Push(bool isProvisional) {
+                if (_cardinalitiesStack.Count == 0) {
+                    int n = _choiceCardinalities.Length;
+                    _cardinalitiesStack.Push(new CardinalityState(new int[n], isProvisional));
+                }
+                else {
+                    _cardinalitiesStack.Push(new CardinalityState(_cardinalitiesStack.Peek().Cardinalities(), isProvisional));
+                }
+            }
+
+            public bool CheckCardinality(bool isLookahead) {
+                if (isLookahead) {
+                    var finalized = new CardinalityState(new int[_choiceCardinalities.Length], false);
+                    if (_cardinalitiesStack.Count == 1) {
+                        finalized = _cardinalitiesStack.Pop();
+                    }
+                    int[] fc = finalized.Cardinalities();
+                    for (int i = 0; i < fc.Length; i++) {
+                        if (fc[i] < _choiceCardinalities[i][0]) {
+                            return false;
+                        }
+                    }
+                }
+                else {
+                    for (int i = 0; i < _choiceCardinalities.Length; i++) {
+                        if (_cardinalities[i] < _choiceCardinalities[i][0]) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            public void CommitIteration(bool isParsing) {
+                if (_cardinalitiesStack.Peek().IsProvisional) {
+                    CardinalityState current = _cardinalitiesStack.Pop();
+                    _cardinalitiesStack.Pop();
+                    _cardinalitiesStack.Push(new CardinalityState(current.Cardinalities(), false));
+                }
+                else if (isParsing) {
+                    _cardinalitiesStack.Pop();
+                    _cardinalitiesStack.Push(new CardinalityState((int[])_cardinalities.Clone(), false));
+                }
+            }
+
+            public bool Commit(bool isSuccess) {
+                if (_cardinalitiesStack.Count > 0 && _cardinalitiesStack.Peek().IsProvisional) {
+                    if (!isSuccess) {
+                        _cardinalitiesStack.Pop();
+                        Debug.Assert(!_cardinalitiesStack.Peek().IsProvisional, "provisional frames should always be on top of a non-provisional frame.");
+                    }
+                }
+                return isSuccess;
+            }
+        }
+#endif
+
         public string InputSource { get; private set; }
         public Token LastConsumedToken { get; private set; }
         private Token currentLookaheadToken;

--- a/src/templates/csharp/ParserProductions.inc.ctl
+++ b/src/templates/csharp/ParserProductions.inc.ctl
@@ -661,7 +661,11 @@ ${globals::translateCodeBlock(fail.code, 1)}
   #set optionalPart = " + " + globals::translateExpression(assertion.messageExpression)
 #endif
    #var assertionMessage = "Assertion at: " + assertion.location?j_string + " failed. "
-   #if assertion.assertionExpression??
+   #if assertion.lookBehind??
+if ([#if !assertion.lookBehind.negated]![/#if]${assertion.lookBehind.routineName}()) {
+    Fail("${assertionMessage}"${optionalPart});
+}
+   #elseif assertion.assertionExpression??
 if (!(${globals::translateExpression(assertion.assertionExpression)})) {
     Fail("${assertionMessage}"${optionalPart});
 }

--- a/src/templates/python/common_utils.inc.ctl
+++ b/src/templates/python/common_utils.inc.ctl
@@ -148,3 +148,10 @@ ${is}        self._next_token_type = None
 [#-- ${is}# DBG < HandleLexicalStateChange ${indent} ${expansion.simpleName} --]
 [/#macro]
 
+[#--
+  Python literal [[min, max], ...] for RepetitionCardinality (mirrors Java CommonUtils.BuildCardinalities).
+--]
+[#macro BuildCardinalities assertions indent]
+[#var is = ""?right_pad(indent)]
+${is}[[#list assertions as range][${range[0]}, ${range[1]}][#if range_has_next], [/#if][/#list]]
+[/#macro]

--- a/src/templates/python/lookahead_routines.inc.ctl
+++ b/src/templates/python/lookahead_routines.inc.ctl
@@ -522,11 +522,15 @@ ${is}    return False
 [#macro ScanCodeAssertion assertion indent]
 [#var is = ""?right_pad(indent)]
 [#-- ${is}# DBG > ScanCodeAssertion ${indent} --]
-#if assertion.assertionExpression??
+[#if assertion.lookBehind??]
+${is}if [#if !assertion.lookBehind.negated]not [/#if]self.${assertion.lookBehind.routineName}():
+${is}    self.hit_failure = True
+${is}    return False
+[#elseif assertion.assertionExpression??]
 ${is}if not (${globals::translateExpression(assertion.assertionExpression)}):
 ${is}    self.hit_failure = True
 ${is}    return False
-#endif
+[/#if]
 [#if assertion.expansion??]
 ${is}if [#if !assertion.expansionNegated]not [/#if]self.${assertion.expansion.scanRoutineName}():
 ${is}    self.hit_failure = True

--- a/src/templates/python/parser.py.ctl
+++ b/src/templates/python/parser.py.ctl
@@ -191,6 +191,95 @@ class InvalidNode(BaseNode):
     pass
 <-
 
+#if grammar.usingCardinality
+class CardinalityState:
+    __slots__ = ('_cardinalities', 'is_provisional')
+
+    def __init__(self, cardinalities, is_provisional):
+        self._cardinalities = list(cardinalities)
+        self.is_provisional = is_provisional
+
+    def cardinalities(self):
+        return list(self._cardinalities)
+
+
+class RepetitionCardinality:
+    __slots__ = ('choice_cardinalities', 'cardinalities_stack', 'cardinalities')
+
+    def __init__(self, choice_cardinalities):
+        n = len(choice_cardinalities)
+        self.choice_cardinalities = choice_cardinalities
+        self.cardinalities_stack = [CardinalityState([0] * n, False)]
+        self.cardinalities = [0] * n
+
+    def choose(self, choice_no, is_lookahead):
+        if not is_lookahead:
+            if self.cardinalities[choice_no] < self.choice_cardinalities[choice_no][1]:
+                self.cardinalities[choice_no] += 1
+                return True
+            return False
+        current_state = self.cardinalities_stack[-1]
+        if not current_state.is_provisional:
+            self.push(True)
+        prior_state = self.cardinalities_stack[-2]
+        current_state = self.cardinalities_stack[-1]
+        current_cardinalities = current_state.cardinalities()
+        prior_cardinalities = prior_state.cardinalities()
+        if current_cardinalities[choice_no] != prior_cardinalities[choice_no]:
+            return True
+        if current_cardinalities[choice_no] < self.choice_cardinalities[choice_no][1]:
+            current_cardinalities[choice_no] += 1
+            self.cardinalities_stack.pop()
+            self.cardinalities_stack.append(
+                CardinalityState(current_cardinalities, True))
+            return True
+        return False
+
+    def push(self, is_provisional):
+        if len(self.cardinalities_stack) == 0:
+            n = len(self.choice_cardinalities)
+            self.cardinalities_stack.append(CardinalityState([0] * n, is_provisional))
+            return
+        top = self.cardinalities_stack[-1]
+        self.cardinalities_stack.append(
+            CardinalityState(top.cardinalities(), is_provisional))
+
+    def check_cardinality(self, is_lookahead):
+        if is_lookahead:
+            finalized = CardinalityState([0] * len(self.choice_cardinalities), False)
+            if len(self.cardinalities_stack) == 1:
+                finalized = self.cardinalities_stack.pop()
+            fc = finalized.cardinalities()
+            for i in range(len(fc)):
+                if fc[i] < self.choice_cardinalities[i][0]:
+                    return False
+            return True
+        for i in range(len(self.choice_cardinalities)):
+            if self.cardinalities[i] < self.choice_cardinalities[i][0]:
+                return False
+        return True
+
+    def commit_iteration(self, is_parsing):
+        if self.cardinalities_stack[-1].is_provisional:
+            current = self.cardinalities_stack.pop()
+            self.cardinalities_stack.pop()
+            self.cardinalities_stack.append(
+                CardinalityState(current.cardinalities(), False))
+            return
+        if is_parsing:
+            self.cardinalities_stack.pop()
+            self.cardinalities_stack.append(
+                CardinalityState(list(self.cardinalities), False))
+
+    def commit(self, is_success):
+        if self.cardinalities_stack and self.cardinalities_stack[-1].is_provisional:
+            if not is_success:
+                self.cardinalities_stack.pop()
+                assert not self.cardinalities_stack[-1].is_provisional
+        return is_success
+
+#endif
+
 class Parser:
 
     __slots__ = (

--- a/src/templates/python/parser_productions.inc.ctl
+++ b/src/templates/python/parser_productions.inc.ctl
@@ -659,7 +659,10 @@ ${is}pass
   [#set optionalPart = " + " + globals::translateExpression(assertion.messageExpression)]
 [/#if]
 [#var assertionMessage = "Assertion at: " + assertion.location?j_string + " failed."]
-[#if assertion.assertionExpression??]
+[#if assertion.lookBehind??]
+${is}if [#if !assertion.lookBehind.negated]not [/#if]self.${assertion.lookBehind.routineName}():
+${is}    self.fail("${assertionMessage}"${optionalPart})
+[#elseif assertion.assertionExpression??]
 ${is}if not (${globals::translateExpression(assertion.assertionExpression)}):
 ${is}    self.fail("${assertionMessage}"${optionalPart})
 [/#if]


### PR DESCRIPTION
Mirror Java BuildAssertionCode and ScanCodeAssertion: handle assertion.lookBehind before assertionExpression, with negation matching BuildPredicateCode lookbehind idioms (not/!).

I happened to be in Cursor and asked it to come up with this.  It looks ok to me.